### PR TITLE
feat: Add mode+command syntax for combined mode switching and command execution

### DIFF
--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -143,7 +143,7 @@ pub fn get_token(self: *Tokenizer) ?Token {
             token.type = .Token_Activate;
             token.line = self.line;
             token.cursor = self.cursor;
-            token.text = self.acceptIdentifier();
+            token.text = self.acceptIdentifierUntilColon();
         },
         ':' => {
             if (self.accept(":") != null) {
@@ -248,6 +248,16 @@ fn acceptIdentifier(self: *Tokenizer) []const u8 {
     _ = self.acceptRun(identifier_chars ++ number_chars);
     const end = self.pos;
     return self.buffer[start..end];
+}
+
+fn acceptIdentifierUntilColon(self: *Tokenizer) []const u8 {
+    const start = self.pos;
+    while (self.peekRune()) |r| {
+        if (r[0] == ':' or r[0] == ' ' or r[0] == '\t' or r[0] == '\n') break;
+        if (std.mem.indexOfScalar(u8, identifier_chars ++ number_chars, r[0]) == null) break;
+        self.moveOver(r);
+    }
+    return self.buffer[start..self.pos];
 }
 
 fn acceptCommand(self: *Tokenizer) []const u8 {

--- a/src/skhd.zig
+++ b/src/skhd.zig
@@ -98,6 +98,20 @@ pub fn init(gpa: std.mem.Allocator, config_file: []const u8, verbose: bool, prof
     };
 }
 
+/// Switch to a target mode, handling both regular modes and default mode
+fn switchToMode(self: *Skhd, mode_name: []const u8) void {
+    if (self.mappings.mode_map.getPtr(mode_name)) |target_mode| {
+        self.current_mode = target_mode;
+        log.info("Switched to mode '{s}'", .{target_mode.name});
+    } else if (std.mem.eql(u8, mode_name, "default")) {
+        // Switching to default mode which should always exist
+        if (self.mappings.mode_map.getPtr("default")) |default_mode| {
+            self.current_mode = default_mode;
+            log.info("Switched to default mode", .{});
+        }
+    }
+}
+
 pub fn deinit(self: *Skhd) void {
     // Print tracer summary before cleanup
     if (self.tracer.enabled) {
@@ -592,6 +606,16 @@ inline fn processHotkey(self: *Skhd, eventkey: *const Hotkey.KeyPress, event: c.
                     // since this is a mode activation hotkey
                     return true;
                 },
+                .mode_with_command => |mode_with_cmd| {
+                    log.debug("Mode activation with command: switching to '{s}' and executing '{s}'", .{mode_with_cmd.mode_name, mode_with_cmd.command});
+                    
+                    // Switch to the target mode
+                    self.switchToMode(mode_with_cmd.mode_name);
+                    
+                    // Execute the command
+                    try forkAndExec(self.mappings.shell, mode_with_cmd.command, self.verbose);
+                    return true;
+                },
                 else => {
                     log.debug("Activate flag set but no command found", .{});
                 },
@@ -615,6 +639,17 @@ inline fn processHotkey(self: *Skhd, eventkey: *const Hotkey.KeyPress, event: c.
                 log.debug("Executing command '{s}' for process {s}", .{ cmd, process_name });
                 self.tracer.traceCommandExecuted();
                 try forkAndExec(self.mappings.shell, cmd, self.verbose);
+                return !hotkey.flags.passthrough;
+            },
+            .mode_with_command => |mode_with_cmd| {
+                log.debug("Executing mode with command: switching to '{s}' and executing '{s}' for process {s}", .{mode_with_cmd.mode_name, mode_with_cmd.command, process_name});
+                
+                // Switch to the target mode
+                self.switchToMode(mode_with_cmd.mode_name);
+                
+                // Execute the command
+                self.tracer.traceCommandExecuted();
+                try forkAndExec(self.mappings.shell, mode_with_cmd.command, self.verbose);
                 return !hotkey.flags.passthrough;
             },
             .unbound => {

--- a/testdata/test_mode_with_command.skhdrc
+++ b/testdata/test_mode_with_command.skhdrc
@@ -1,0 +1,47 @@
+# Test configuration for mode with command syntax
+# Tests the new ;mode : command syntax
+
+# Declare modes
+:: window : echo "Window mode activated"
+:: browser : echo "Browser mode activated"
+:: default
+
+# Define process groups for testing
+.define terminal_apps ["kitty", "wezterm", "terminal"]
+.define browser_apps ["chrome", "safari", "firefox"]
+
+# Test mode activation with command (new syntax)
+cmd - w ; window : echo "Switching to window mode and running command"
+
+# Test mode exit with command
+window < escape ; default : echo "Exiting window mode and running command"
+
+# Test regular mode activation (original syntax for comparison)
+cmd - d ; default
+
+# Test process-specific mode activation with command (NEW FEATURE)
+cmd - m [
+    "iterm"     ; window : echo "iTerm 2 entering window mode"
+    "brave"       ; browser : echo "Brave entering browser mode"
+    @terminal_apps ; window : echo "Terminal apps entering window mode"
+    @browser_apps  ; browser : echo "Browser apps entering browser mode"
+    *              ; default : echo "Other apps entering default mode"
+]
+
+# Test process-specific mode activation without command (original)
+cmd - n [
+    "terminal" ; window
+    "chrome"   ; browser
+    *          ; default
+]
+
+# Test regular commands in window mode
+window < h : echo "Window mode: focus left"
+window < l : echo "Window mode: focus right"
+
+# Test regular commands in browser mode
+browser < h : echo "Browser mode: previous tab"
+browser < l : echo "Browser mode: next tab"
+
+# Test regular hotkeys in default mode  
+cmd - a : echo "Default mode: regular command"


### PR DESCRIPTION
# Add mode+command syntax for combined mode switching and command execution

## Summary

- Adds new syntax `modifier - key ; target_mode : command` to execute commands while switching modes
- Supports the new syntax in all contexts: global hotkeys, process-specific mappings, and process groups

## Motivation

The original skhd treated mode changes (`;`) and command execution (`:`) as mutually exclusive operations. This limitation required workarounds for common use cases:

1. **One-shot commands and modes**: Users wanted to execute a command and return to the default mode without staying in the target mode
2. **Exit commands**: Users wanted to execute commands when exiting a mode (more flexible than a hypothetical `on exit` event)

The previous workaround involved synthesizing key presses from shell commands to programmatically change modes (as suggested in [koekeishiya/skhd#37](https://github.com/koekeishiya/skhd/issues/37)), but this approach has significant issues:
- **Reliability**: Synthesized keys can be missed or misinterpreted due to race conditions
- **Flexibility**: Requires defining additional hotkeys for every mode transition, creating unwanted direct mode changes that could trigger accidentally

## Implementation

### New Syntax Examples

**Basic mode + command:**
```bash
cmd - w ; window : echo "Entering window mode"
```

**Process-specific mode + command:**
```bash
cmd - m [
    "terminal"     ; window : echo "Terminal entering window mode"
    "chrome"       ; browser : echo "Chrome entering browser mode"
    @terminal_apps ; window : echo "Terminal apps entering window mode"
    *              ; default : echo "Other apps entering default mode"
]
```

### Technical Changes

**Core Components Modified:**
1. **Tokenizer**: Added `acceptIdentifierUntilColon()` method to parse mode names that stop at `:`
2. **Data Structures**: Extended `ProcessCommand` union with `mode_with_command` variant
3. **Parser**: Added support for parsing `;mode : command` syntax with helper functions to eliminate code duplication
4. **Runtime**: Added `switchToMode()` helper and extended hotkey processing for the new variant