### PR TITLE
add special character "backtick" (`)

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -136,6 +136,7 @@ command   = command is executed through '$SHELL -c'
 - `backspace` - Delete/Backspace (kVK_Delete)
 - `delete` - Forward Delete (kVK_ForwardDelete)
 - `escape` - Escape key
+- `backtick` - Backtick/Grave Accent key (`)
 
 ### Function Keys
 - `f1` through `f20` - Function keys

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -38,7 +38,7 @@
     .dependencies = .{
         .zbench = .{
             .url = "https://github.com/hendriknielaender/zBench/archive/refs/heads/main.tar.gz",
-            .hash = "zbench-0.10.0-YTdc714iAQDO4lTHMnIljYHPZ5v_sNTsw75vAmO1pyT-",
+            .hash = "zbench-0.11.0-YTdc75klAQDX2m3fa_EHmQA_wJDgBIGiWXXX091e3qUQ",
         },
     },
     .paths = .{

--- a/src/Keycodes.zig
+++ b/src/Keycodes.zig
@@ -109,8 +109,8 @@ test "is_modifier" {
 }
 
 pub const literal_keycode_str = [_][]const u8{
-    "return",          "tab",           "space",
-    "backspace",       "escape",
+    "return",          "tab",             "space",
+    "backspace",       "escape",          "backtick",
 
     // zig fmt: off
 
@@ -139,7 +139,7 @@ pub const KEY_HAS_IMPLICIT_NX_MOD = 35;
 
 pub const literal_keycode_value = [_]u32{
     c.kVK_Return,                 c.kVK_Tab,                  c.kVK_Space,
-    c.kVK_Delete,                 c.kVK_Escape,
+    c.kVK_Delete,                 c.kVK_Escape,               c.kVK_ANSI_Grave,
 
     // zig fmt: off
 


### PR DESCRIPTION
Introduces support for `backtick` as a special literal character

Test it like
```
alt - backtick : open -a "Ghostty"
```
