### PR TITLE
Add key alias support (closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The service will:
 
 ### Additional Features (New in skhd.zig!)
 
+- **Key aliases**: Define reusable aliases for modifiers, keys, and key combinations
 - **Process groups**: Define named groups of applications for cleaner configs
 - **Command definitions**: Define reusable commands with placeholders to reduce repetition
 - **Key Forwarding**: Forward / remap key binding to another key binding
@@ -183,6 +184,12 @@ The configuration syntax is fully compatible with the original skhd. See [SYNTAX
 
 # Load additional config files
 .load "~/.config/skhd/extra.skhdrc"
+
+# Define key aliases for reusable modifier/key combinations (New in skhd.zig!)
+.alias $super cmd + alt
+.alias $mega cmd + alt + shift + ctrl
+.alias $grave 0x32                      # UK keyboard backtick
+.alias $nav_left $super - h
 
 # Define process groups for reuse (New in skhd.zig!)
 .define terminal_apps ["kitty", "wezterm", "terminal"]
@@ -369,23 +376,31 @@ resize < escape ; winmode
 ### Window Management Example
 
 ```bash
-# Focus windows using command definitions (New in skhd.zig!)
-cmd - h : @yabai_focus("west")
-cmd - j : @yabai_focus("south")
-cmd - k : @yabai_focus("north")
-cmd - l : @yabai_focus("east")
+# Define aliases for cleaner config (New in skhd.zig!)
+.alias $super cmd + alt
+.alias $mega $super + shift
 
-# Move/swap windows using command definitions
-cmd + shift - h : @yabai_swap("west")
-cmd + shift - j : @yabai_swap("south")
-cmd + shift - k : @yabai_swap("north")
-cmd + shift - l : @yabai_swap("east")
+# Focus windows using command definitions and aliases
+$super - h : @yabai_focus("west")
+$super - j : @yabai_focus("south")
+$super - k : @yabai_focus("north")
+$super - l : @yabai_focus("east")
 
-# Resize windows using command definitions
-cmd + ctrl - h : @resize_window("left", "-20", "0")
-cmd + ctrl - l : @resize_window("right", "20", "0")
+# Move/swap windows using nested alias
+$mega - h : @yabai_swap("west")
+$mega - j : @yabai_swap("south")
+$mega - k : @yabai_swap("north")
+$mega - l : @yabai_swap("east")
 
-# Switch spaces
+# Define keysym aliases for common operations
+.alias $focus_west $super - h
+.alias $focus_east $super - l
+
+# Use keysym alias standalone or with additional modifiers
+$focus_west : @yabai_focus("west")
+ctrl + $focus_west : @yabai_focus("west")  # With extra modifier
+
+# Traditional syntax still works
 cmd - 1 : yabai -m space --focus 1
 cmd - 2 : yabai -m space --focus 2
 ```

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -36,6 +36,7 @@ pub const TokenType = enum {
     Token_String,
     Token_Option,
     Token_Reference,
+    Token_Alias,
 
     Token_BeginList,
     Token_EndList,
@@ -109,6 +110,19 @@ pub fn get_token(self: *Tokenizer) ?Token {
             } else {
                 // It's just @ (used for capture in mode declarations)
                 token.type = .Token_Capture;
+            }
+        },
+        '$' => {
+            // Check if this is followed by an identifier
+            const next = self.peekRune();
+            if (next != null and ascii.isAlphabetic(next.?[0])) {
+                // It's an alias like $hyper or $grave
+                token.type = .Token_Alias;
+                // Don't include the $ in the token text
+                token.text = self.acceptIdentifier();
+            } else {
+                // Standalone $ is unknown/error
+                token.type = .Token_Unknown;
             }
         },
         '~' => token.type = .Token_Unbound,

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -512,7 +512,7 @@ test "Parser error messages" {
     try testing.expectError(error.ParseErrorOccurred, err4);
     try testing.expect(parser.error_info != null);
     const parse_err4 = parser.error_info.?;
-    try testing.expectEqualStrings("Expected key, key hex, or literal", parse_err4.message);
+    try testing.expectEqualStrings("Expected key, key hex, literal, or alias", parse_err4.message);
 
     // Test empty process list
     parser.clearError();


### PR DESCRIPTION
Implements key aliases feature allowing users to define reusable names for modifiers, keys, and key combinations, making configs more readable and maintainable.

Features:
- Three alias types: modifier, key, and keysym
- Full recursive expansion at parse time (zero runtime overhead)
- Circular reference detection with helpful error messages
- Nested alias support (aliases can reference other aliases)
- Compatible with existing syntax (modifiers combine like hyper/meh)

Syntax:
  .alias $super cmd + alt           # Modifier alias
  .alias $grave 0x32                # Key alias
  .alias $nav_left $super - h       # Keysym alias

Usage:
  $super - t : command              # Use modifier alias
  ctrl - $grave : command           # Use key alias
  $nav_left : command               # Use keysym standalone
  ctrl + $nav_left : command        # Add modifiers to keysym

Implementation:
- Tokenizer: Added Token_Alias for $identifier syntax
- Parser: Added Alias union type with storage and resolution logic
- Comprehensive error messages for type mismatches and undefined aliases
- Full test coverage for all alias types and error cases
- Documentation in SYNTAX.md and README.md with examples

Inspired by koekeishiya/skhd#288