### PR TITLE
Add Zig 0.15 support; require Zig 0.15.0 as minimum version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: 0.14.0
+        version: 0.15.2
     
     - name: Run tests
       run: zig build test
@@ -38,7 +38,7 @@ jobs:
     - name: Setup Zig
       uses: mlugg/setup-zig@v2
       with:
-        version: 0.14.0
+        version: 0.15.2
     
     - name: Build ${{ matrix.optimize }}
       run: zig build -Doptimize=${{ matrix.optimize }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ zig-out/
 /build-*/
 /docgen_tmp/
 /.claude/settings.local.json
+PR_DESCRIPTION.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Zig 0.15** - Updated codebase to build with Zig 0.15.0 (minimum supported version)
+  - Build API: `addExecutable`/`addTest` use `root_module` and `b.createModule()`
+  - C import: `@cImport` result exposed as `c_impl`; callers use `@import("c.zig").c_impl` and `@import("c.zig").NSApplicationLoad()`
+  - Stdlib: `std.ArrayList` → `std.array_list.Managed`, `std.time.sleep` → `std.Thread.sleep`, `stderr.reader()` → `stderr.deprecatedReader()`, `std.posix.empty_sigset` → `std.posix.sigemptyset()`, `callconv(.C)` → `callconv(.c)`
+  - Format: custom `format` methods use Zig 0.15 signature `(self, writer)`; use `{f}` where format is intended
+  - CI: workflow now uses Zig 0.15.0
+  - **Breaking:** Zig 0.14 and earlier are no longer supported
+
 ## [0.0.17] - 2025-12-08
 
 ### Added

--- a/build.zig
+++ b/build.zig
@@ -53,12 +53,13 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    // Main executable
     const exe = b.addExecutable(.{
         .name = "skhd",
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const options = b.addOptions();
@@ -93,32 +94,34 @@ pub fn build(b: *std.Build) void {
 
     const test_step = b.step("test", "Run unit tests");
 
-    // Benchmark executable
-    const bench_exe = b.addExecutable(.{
-        .name = "benchmark",
-        .root_source_file = b.path("src/benchmark.zig"),
-        .target = target,
-        .optimize = .ReleaseFast,
-    });
-    linkFrameworks(bench_exe);
-    addVersionImport(b, bench_exe);
-
-    const zbench = b.dependency("zbench", .{
-        .target = target,
-        .optimize = .ReleaseFast,
-    });
-    bench_exe.root_module.addImport("zbench", zbench.module("zbench"));
-
-    const bench_cmd = b.addRunArtifact(bench_exe);
-    const bench_step = b.step("bench", "Run benchmarks");
-    bench_step.dependOn(&bench_cmd.step);
+    // Benchmark executable (disabled: zbench is not yet compatible with Zig 0.15)
+    // const bench_exe = b.addExecutable(.{
+    //     .name = "benchmark",
+    //     .root_module = b.createModule(.{
+    //         .root_source_file = b.path("src/benchmark.zig"),
+    //         .target = target,
+    //         .optimize = .ReleaseFast,
+    //     }),
+    // });
+    // linkFrameworks(bench_exe);
+    // addVersionImport(b, bench_exe);
+    // const zbench = b.dependency("zbench", .{
+    //     .target = target,
+    //     .optimize = .ReleaseFast,
+    // });
+    // bench_exe.root_module.addImport("zbench", zbench.module("zbench"));
+    // const bench_cmd = b.addRunArtifact(bench_exe);
+    // const bench_step = b.step("bench", "Run benchmarks");
+    // bench_step.dependOn(&bench_cmd.step);
 
     // Allocation tracking executable
     const alloc_exe = b.addExecutable(.{
         .name = "skhd-alloc",
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     linkFrameworks(alloc_exe);
     addVersionImport(b, alloc_exe);
@@ -135,9 +138,11 @@ pub fn build(b: *std.Build) void {
 
     // Tests for main.zig
     const exe_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     linkFrameworks(exe_unit_tests);
     addVersionImport(b, exe_unit_tests);
@@ -148,9 +153,11 @@ pub fn build(b: *std.Build) void {
 
     // Tests for tests.zig
     const tests_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/tests.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/tests.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     linkFrameworks(tests_unit_tests);
     addVersionImport(b, exe_unit_tests);
@@ -171,9 +178,11 @@ pub fn build(b: *std.Build) void {
 
     for (test_files) |test_file| {
         const module_tests = b.addTest(.{
-            .root_source_file = b.path(test_file),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(test_file),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         linkFrameworks(module_tests);
         addVersionImport(b, module_tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -28,7 +28,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/src/CarbonEvent.zig
+++ b/src/CarbonEvent.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 
 const CarbonEvent = @This();
 const log = std.log.scoped(.carbon_event);

--- a/src/EventTap.zig
+++ b/src/EventTap.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 
 handle: c.CFMachPortRef = null,
 runloop_source: c.CFRunLoopSourceRef = null,

--- a/src/Hotkey.zig
+++ b/src/Hotkey.zig
@@ -210,8 +210,7 @@ pub const ProcessCommand = union(enum) {
     }
 };
 
-pub fn format(self: *const Hotkey, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-    _ = fmt;
+pub fn format(self: *const Hotkey, writer: anytype) !void {
     try writer.print("Hotkey{{", .{});
     try writer.print("\n  mode_list: {{", .{});
     {
@@ -221,7 +220,7 @@ pub fn format(self: *const Hotkey, comptime fmt: []const u8, _: std.fmt.FormatOp
         }
     }
     try writer.print("}}", .{});
-    try writer.print("\n  flags: {}", .{self.flags});
+    try writer.print("\n  flags: {f}", .{self.flags});
     try writer.print("\n  key: {}", .{self.key});
     try writer.print("\n  process_mappings: {} entries", .{self.mappings.count()});
     try writer.print("\n}}", .{});

--- a/src/Hotload.zig
+++ b/src/Hotload.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 
 /// File system event monitoring using macOS FSEvents API.
 ///
@@ -20,7 +20,7 @@ const WatchedFile = struct {
 // Core fields
 allocator: std.mem.Allocator,
 callback: Callback,
-watch_list: std.ArrayList(WatchedFile),
+watch_list: std.array_list.Managed(WatchedFile),
 enabled: bool = false,
 
 // FSEvents fields
@@ -36,7 +36,7 @@ pub fn create(allocator: std.mem.Allocator, callback: Callback) !*Hotload {
     self.* = .{
         .allocator = allocator,
         .callback = callback,
-        .watch_list = std.ArrayList(WatchedFile).init(allocator),
+        .watch_list = std.array_list.Managed(WatchedFile).init(allocator),
         .enabled = false,
         .stream = null,
         .paths = null,
@@ -207,7 +207,7 @@ fn fseventsCallback(
     event_paths: ?*anyopaque,
     event_flags: [*c]const c.FSEventStreamEventFlags,
     event_ids: [*c]const c.FSEventStreamEventId,
-) callconv(.C) void {
+) callconv(.c) void {
     _ = stream;
     _ = event_flags;
     _ = event_ids;
@@ -267,7 +267,7 @@ test "hotload file watching" {
     const TimerContext = struct {
         count: u32 = 0,
 
-        fn timerCallback(timer: c.CFRunLoopTimerRef, info: ?*anyopaque) callconv(.C) void {
+        fn timerCallback(timer: c.CFRunLoopTimerRef, info: ?*anyopaque) callconv(.c) void {
             _ = timer;
             const self = @as(*@This(), @ptrCast(@alignCast(info.?)));
             self.count += 1;

--- a/src/Keycodes.zig
+++ b/src/Keycodes.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 const log = std.log.scoped(.keycodes);
 
 const layout_dependent_keycodes = [_]u32{
@@ -59,9 +59,7 @@ pub const ModifierFlag = packed struct(u32) {
         const m2: u32 = @bitCast(other);
         return @bitCast(m1 | m2);
     }
-    pub fn format(self: *const ModifierFlag, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-        _ = fmt;
-
+    pub fn format(self: *const ModifierFlag, writer: anytype) !void {
         var i: u32 = 0;
         inline for (@typeInfo(@This()).@"struct".fields) |field| {
             const name = field.name;
@@ -79,7 +77,7 @@ pub const ModifierFlag = packed struct(u32) {
 test "format ModifierFlag" {
     const flag = ModifierFlag{ .alt = true, .shift = true };
     // Verify formatting works without printing
-    const formatted = try std.fmt.allocPrint(std.testing.allocator, "{s}", .{flag});
+    const formatted = try std.fmt.allocPrint(std.testing.allocator, "{f}", .{flag});
     defer std.testing.allocator.free(formatted);
     try std.testing.expectEqualStrings("alt, shift", formatted);
 }

--- a/src/Mappings.zig
+++ b/src/Mappings.zig
@@ -83,17 +83,14 @@ pub fn add_blacklist(self: *Mappings, key: []const u8) !void {
     try self.blacklist.put(self.allocator, owned, void{});
 }
 
-pub fn format(self: *const Mappings, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-    // if (fmt.len != 0) {
-    //     std.fmt.invalidFmtError(fmt, self);
-    // }
-    _ = fmt;
+pub fn format(self: *const Mappings, writer: anytype) !void {
     try writer.print("Mappings {{", .{});
     try writer.print("\n  mode_map: {{", .{});
     {
         var it = self.mode_map.iterator();
         while (it.next()) |kv| {
-            try utils.indentPrint(self.allocator, writer, "    ", "\n{}", kv.value_ptr.*);
+            try writer.print("\n    ", .{});
+            try kv.value_ptr.*.format(writer);
         }
     }
     try writer.print("\n  }}", .{});
@@ -162,7 +159,7 @@ test "format" {
     defer mappings.deinit();
     const mode = try mappings.get_mode_or_create_default("default");
     // Just verify the formatting doesn't crash
-    const formatted = try std.fmt.allocPrint(alloc, "{}", .{mappings});
+    const formatted = try std.fmt.allocPrint(alloc, "{f}", .{mappings});
     defer alloc.free(formatted);
     try std.testing.expect(formatted.len > 0);
     try std.testing.expect(mode != null);

--- a/src/Mode.zig
+++ b/src/Mode.zig
@@ -41,11 +41,7 @@ pub fn set_command(self: *Mode, command: []const u8) !void {
     self.command = try self.allocator.dupeZ(u8, command);
 }
 
-pub fn format(self: *const Mode, comptime fmt: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
-    // if (fmt.len != 0) {
-    //     std.fmt.invalidFmtError(fmt, self);
-    // }
-    _ = fmt;
+pub fn format(self: *const Mode, writer: anytype) !void {
     try writer.print("Mode{{", .{});
     try writer.print("\n  name: {s}", .{self.name});
     try writer.print("\n  command: {?s}", .{self.command});
@@ -55,7 +51,8 @@ pub fn format(self: *const Mode, comptime fmt: []const u8, _: std.fmt.FormatOpti
     {
         var it = self.hotkey_map.iterator();
         while (it.next()) |kv| {
-            try utils.indentPrint(self.allocator, writer, "    ", "{}", kv.key_ptr.*);
+            try writer.print("\n    ", .{});
+            try kv.key_ptr.*.format(writer);
         }
     }
     try writer.print("\n  }}", .{});

--- a/src/ParseError.zig
+++ b/src/ParseError.zig
@@ -9,7 +9,7 @@ pub const ParseError = struct {
     file_path: ?[]const u8,
     token_text: ?[]const u8,
 
-    pub fn format(self: ParseError, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(self: ParseError, writer: anytype) !void {
         if (self.file_path) |path| {
             try writer.print("{s}:", .{path});
         }
@@ -50,12 +50,12 @@ pub const ParseError = struct {
 
 pub const ParseErrorContext = struct {
     allocator: std.mem.Allocator,
-    errors: std.ArrayList(ParseError),
+    errors: std.array_list.Managed(ParseError),
 
     pub fn init(allocator: std.mem.Allocator) ParseErrorContext {
         return ParseErrorContext{
             .allocator = allocator,
-            .errors = std.ArrayList(ParseError).init(allocator),
+            .errors = std.array_list.Managed(ParseError).init(allocator),
         };
     }
 
@@ -69,7 +69,7 @@ pub const ParseErrorContext = struct {
 
     pub fn printErrors(self: *ParseErrorContext, writer: anytype) !void {
         for (self.errors.items) |err| {
-            try writer.print("{}\n", .{err});
+            try writer.print("{f}\n", .{err});
         }
     }
 };

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 const Tokenizer = @import("Tokenizer.zig");
 const Token = Tokenizer.Token;
 const Hotkey = @import("Hotkey.zig");
@@ -25,7 +25,7 @@ content: []const u8 = undefined,
 previous_token: ?Token = undefined,
 next_token: ?Token = undefined,
 keycodes: Keycodes = undefined,
-load_directives: std.ArrayList(LoadDirective) = undefined,
+load_directives: std.array_list.Managed(LoadDirective) = undefined,
 current_file_path: ?[]const u8 = null,
 error_info: ?ParseError = null,
 process_groups: std.StringHashMapUnmanaged([][]const u8) = .empty,
@@ -106,7 +106,7 @@ pub fn init(allocator: std.mem.Allocator) !Parser {
         .previous_token = null,
         .next_token = null,
         .keycodes = try Keycodes.init(allocator),
-        .load_directives = std.ArrayList(LoadDirective).init(allocator),
+        .load_directives = std.array_list.Managed(LoadDirective).init(allocator),
     };
 }
 
@@ -194,7 +194,7 @@ fn match(self: *Parser, typ: Tokenizer.TokenType) bool {
 
 /// Process escape sequences in a string, replacing \\ with \ and \" with "
 fn processStringOwned(self: *Parser, str: []const u8) ![]const u8 {
-    var result = std.ArrayList(u8).init(self.allocator);
+    var result = std.array_list.Managed(u8).init(self.allocator);
     errdefer result.deinit();
 
     var i: usize = 0;
@@ -339,7 +339,7 @@ fn parse_hotkey(self: *Parser, mappings: *Mappings) !void {
             const key_str = try Keycodes.formatKeyPressBuffer(&buf, hotkey.flags, hotkey.key);
 
             // Get the mode(s) where we're trying to add this hotkey
-            var mode_names = std.ArrayList(u8).init(self.allocator);
+            var mode_names = std.array_list.Managed(u8).init(self.allocator);
             defer mode_names.deinit();
 
             var it = hotkey.mode_list.iterator();
@@ -770,7 +770,7 @@ fn parse_command_reference(self: *Parser) ![]const u8 {
     // Check for opening parenthesis
     if (self.match(.Token_BeginTuple)) {
         // Parse arguments
-        var args = std.ArrayList([]const u8).init(self.allocator);
+        var args = std.array_list.Managed([]const u8).init(self.allocator);
         defer args.deinit();
         defer for (args.items) |arg| {
             self.allocator.free(arg);
@@ -820,7 +820,7 @@ fn parse_command_reference(self: *Parser) ![]const u8 {
         }
 
         // Expand the template using pre-parsed parts
-        var result = std.ArrayList(u8).init(self.allocator);
+        var result = std.array_list.Managed(u8).init(self.allocator);
         errdefer result.deinit();
 
         for (cmd_def.parts) |part| {
@@ -845,7 +845,7 @@ fn parse_command_reference(self: *Parser) ![]const u8 {
         return error.ParseErrorOccurred;
     } else {
         // No arguments needed, build from parts
-        var result = std.ArrayList(u8).init(self.allocator);
+        var result = std.array_list.Managed(u8).init(self.allocator);
         errdefer result.deinit();
 
         for (cmd_def.parts) |part| {
@@ -860,7 +860,7 @@ fn parse_command_reference(self: *Parser) ![]const u8 {
 }
 
 fn parseCommandTemplate(self: *Parser, template: []const u8, token: Token) !CommandDef {
-    var parts = std.ArrayList(CommandDef.Part).init(self.allocator);
+    var parts = std.array_list.Managed(CommandDef.Part).init(self.allocator);
     errdefer {
         for (parts.items) |part| {
             part.deinit(self.allocator);
@@ -964,7 +964,7 @@ fn parse_option(self: *Parser, mappings: *Mappings) !void {
             try self.command_defs.put(self.allocator, owned_name, parsed);
         } else if (self.match(.Token_BeginList)) {
             // Process group definition: define name ["app1", "app2"]
-            var process_list = std.ArrayList([]const u8).init(self.allocator);
+            var process_list = std.array_list.Managed([]const u8).init(self.allocator);
             errdefer {
                 for (process_list.items) |process| self.allocator.free(process);
                 process_list.deinit();

--- a/src/Tokenizer.zig
+++ b/src/Tokenizer.zig
@@ -52,7 +52,7 @@ pub const Token = struct {
     line: usize,
     cursor: usize,
 
-    pub fn format(self: *const Token, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+    pub fn format(self: *const Token, writer: anytype) !void {
         try writer.print("Token{{", .{});
         try writer.print("\n  line: {d}", .{self.line});
         try writer.print("\n  cursor: {d}", .{self.cursor});
@@ -332,7 +332,7 @@ test "nextRune" {
         \\
     ;
     var tokenizer = try init(content);
-    var got = std.ArrayList(u8).init(std.testing.allocator);
+    var got = std.array_list.Managed(u8).init(std.testing.allocator);
     defer got.deinit();
     while (tokenizer.peekRune()) |rune| {
         try got.appendSlice(rune);

--- a/src/TrackingAllocator.zig
+++ b/src/TrackingAllocator.zig
@@ -121,7 +121,7 @@ fn alloc(ctx: *anyopaque, len: usize, alignment: std.mem.Alignment, ret_addr: us
     }
 
     // Always log allocations
-    const stderr = std.io.getStdErr().writer();
+    const stderr = std.fs.File.stderr().deprecatedWriter();
     stderr.print("[ALLOC] {} bytes at 0x{x} (total: {}, peak: {})\n", .{
         len,
         addr,
@@ -160,7 +160,7 @@ fn resize(ctx: *anyopaque, buf: []u8, buf_align: std.mem.Alignment, new_len: usi
         }
 
         // Always log resizes
-        const stderr = std.io.getStdErr().writer();
+        const stderr = std.fs.File.stderr().deprecatedWriter();
         stderr.print("[RESIZE] {} -> {} bytes at 0x{x} (total: {})\n", .{
             old_size,
             new_len,
@@ -184,7 +184,7 @@ fn free(ctx: *anyopaque, buf: []u8, buf_align: std.mem.Alignment, ret_addr: usiz
         self.total_deallocations += 1;
 
         // Always log frees
-        const stderr = std.io.getStdErr().writer();
+        const stderr = std.fs.File.stderr().deprecatedWriter();
         stderr.print("[FREE] {} bytes at 0x{x} (total: {})\n", .{
             entry.value.size,
             addr,
@@ -279,7 +279,7 @@ pub fn printReport(self: *TrackingAllocator, writer: anytype) !void {
 fn dumpStackTrace(trace: std.builtin.StackTrace) void {
     if (trace.index == 0) return;
 
-    const stderr = std.io.getStdErr().writer();
+    const stderr = std.fs.File.stderr().deprecatedWriter();
     // Simple stack trace dumping for now - just print the addresses
     stderr.print("Stack trace:\n", .{}) catch {};
     for (trace.instruction_addresses[0..trace.index]) |addr| {

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -3,7 +3,7 @@ const zbench = @import("zbench");
 const Skhd = @import("skhd.zig");
 const Hotkey = @import("Hotkey.zig");
 const HotkeyOriginal = @import("Hotkey.zig");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 const ModifierFlag = @import("Keycodes.zig").ModifierFlag;
 
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -179,5 +179,5 @@ pub fn main() !void {
     try bench.add("Process Mapping (Original)", benchProcessMappingOriginal, .{});
 
     // Run benchmarks
-    try bench.run(std.io.getStdOut().writer());
+    try bench.run(std.fs.File.stdout().deprecatedWriter());
 }

--- a/src/c.zig
+++ b/src/c.zig
@@ -1,5 +1,4 @@
-// Unified C imports for the project
-pub usingnamespace @cImport({
+pub const c_impl = @cImport({
     @cInclude("Carbon/Carbon.h");
     @cInclude("CoreServices/CoreServices.h");
     @cInclude("objc/objc.h");
@@ -11,5 +10,5 @@ pub usingnamespace @cImport({
     @cInclude("IOKit/hidsystem/ev_keymap.h");
 });
 
-// Additional declarations
+// Additional declarations (module-level, not inside c_impl)
 pub extern fn NSApplicationLoad() void;

--- a/src/echo.zig
+++ b/src/echo.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const EventTap = @import("EventTap.zig");
 const Keycodes = @import("Keycodes.zig");
 
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 
 extern fn NSApplicationLoad() void;
 

--- a/src/exec.zig
+++ b/src/exec.zig
@@ -1,4 +1,4 @@
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 const std = @import("std");
 
 /// Fork and exec a command, detaching it from the parent process

--- a/src/main.zig
+++ b/src/main.zig
@@ -38,7 +38,7 @@ pub fn main() !void {
 
     defer if (comptime track_alloc) {
         std.debug.print("\n=== Final Allocation Report ===\n", .{});
-        tracker.printReport(std.io.getStdErr().writer()) catch {};
+        tracker.printReport(std.fs.File.stderr().deprecatedWriter()) catch {};
         tracker.deinit();
     };
 

--- a/src/service.zig
+++ b/src/service.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 const log = std.log.scoped(.service);
 
 // Import C function
@@ -188,11 +188,11 @@ pub fn startService(allocator: std.mem.Allocator) !void {
     try child.spawn();
 
     // Collect stderr to show any launchctl errors
-    var stderr_data = std.ArrayList(u8).init(allocator);
+    var stderr_data = std.array_list.Managed(u8).init(allocator);
     defer stderr_data.deinit();
 
     if (child.stderr) |stderr| {
-        try stderr.reader().readAllArrayList(&stderr_data, 8192);
+        try stderr.deprecatedReader().readAllArrayList(&stderr_data, 8192);
     }
 
     const term = try child.wait();
@@ -233,7 +233,7 @@ pub fn stopService(allocator: std.mem.Allocator) !void {
 pub fn restartService(allocator: std.mem.Allocator) !void {
     try stopService(allocator);
     // Small delay to ensure service is fully stopped
-    std.time.sleep(1 * std.time.ns_per_s);
+    std.Thread.sleep(1 * std.time.ns_per_s);
     try startService(allocator);
 }
 

--- a/src/skhd.zig
+++ b/src/skhd.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 const CarbonEvent = @import("CarbonEvent.zig");
 const EventTap = @import("EventTap.zig");
 const forkAndExec = @import("exec.zig").forkAndExec;
@@ -54,7 +54,7 @@ pub fn init(gpa: std.mem.Allocator, config_file: []const u8, verbose: bool, prof
 
     parser.parseWithPath(&mappings, content, config_file) catch |err| {
         if (parser.error_info) |parse_err| {
-            log.err("skhd: {}", .{parse_err});
+            log.err("skhd: {f}", .{parse_err});
         }
         return err;
     };
@@ -70,7 +70,7 @@ pub fn init(gpa: std.mem.Allocator, config_file: []const u8, verbose: bool, prof
 
     // Log loaded modes
     var mode_iter = mappings.mode_map.iterator();
-    var modes_list = std.ArrayList(u8).init(gpa);
+    var modes_list = std.array_list.Managed(u8).init(gpa);
     defer modes_list.deinit();
     while (mode_iter.next()) |entry| {
         try modes_list.writer().print("'{s}' ", .{entry.key_ptr.*});
@@ -104,7 +104,7 @@ pub fn init(gpa: std.mem.Allocator, config_file: []const u8, verbose: bool, prof
 pub fn deinit(self: *Skhd) void {
     // Print tracer summary before cleanup
     if (self.tracer.enabled) {
-        const stderr = std.io.getStdErr().writer();
+        const stderr = std.fs.File.stderr().deprecatedWriter();
         self.tracer.printSummary(stderr) catch {};
     }
 
@@ -118,10 +118,9 @@ pub fn deinit(self: *Skhd) void {
 }
 
 pub fn run(self: *Skhd, enable_hotload: bool) !void {
-    // Set up signal handler for config reload
     const usr1_act = std.posix.Sigaction{
         .handler = .{ .handler = handleSigusr1 },
-        .mask = std.posix.empty_sigset,
+        .mask = std.posix.sigemptyset(),
         .flags = 0,
     };
     std.posix.sigaction(std.posix.SIG.USR1, &usr1_act, null);
@@ -129,7 +128,7 @@ pub fn run(self: *Skhd, enable_hotload: bool) !void {
     // Set up signal handler for SIGINT (Ctrl+C) to print trace summary
     const int_act = std.posix.Sigaction{
         .handler = .{ .handler = handleSigint },
-        .mask = std.posix.empty_sigset,
+        .mask = std.posix.sigemptyset(),
         .flags = 0,
     };
     std.posix.sigaction(std.posix.SIG.INT, &int_act, null);
@@ -189,7 +188,7 @@ pub fn run(self: *Skhd, enable_hotload: bool) !void {
     };
 
     // Call NSApplicationLoad() like the original skhd
-    c.NSApplicationLoad();
+    @import("c.zig").NSApplicationLoad();
 
     // Always log successful event tap creation
     log.info("Event tap created successfully. skhd is now running.", .{});
@@ -505,7 +504,7 @@ fn nsEventOtherEvent(ns_event_class: c.id, event_type: c_ulong, subtype: c_short
         c_short,
         c_long,
         c_long,
-    ) callconv(.C) c.id, .{ .name = "objc_msgSend" });
+    ) callconv(.c) c.id, .{ .name = "objc_msgSend" });
 
     return msgSend(
         ns_event_class,
@@ -526,7 +525,7 @@ fn nsEventOtherEvent(ns_event_class: c.id, event_type: c_ulong, subtype: c_short
 /// Get CGEvent from NSEvent by calling [event CGEvent]
 fn nsEventToCGEvent(ns_event: c.id) c.CGEventRef {
     const sel = c.sel_registerName("CGEvent");
-    const msgSend = @extern(*const fn (c.id, c.SEL) callconv(.C) ?*anyopaque, .{ .name = "objc_msgSend" });
+    const msgSend = @extern(*const fn (c.id, c.SEL) callconv(.c) ?*anyopaque, .{ .name = "objc_msgSend" });
     return @ptrCast(msgSend(ns_event, sel));
 }
 
@@ -667,7 +666,7 @@ inline fn processHotkey(self: *Skhd, eventkey: *const Hotkey.KeyPress, event: c.
 }
 
 /// Signal handler for SIGUSR1 - reload configuration
-fn handleSigusr1(_: c_int) callconv(.C) void {
+fn handleSigusr1(_: c_int) callconv(.c) void {
     if (global_skhd) |skhd| {
         log.info("Received SIGUSR1, reloading configuration", .{});
         skhd.reloadConfig() catch |err| {
@@ -677,7 +676,7 @@ fn handleSigusr1(_: c_int) callconv(.C) void {
 }
 
 /// Signal handler for SIGINT - stop the run loop to allow graceful shutdown
-fn handleSigint(_: c_int) callconv(.C) void {
+fn handleSigint(_: c_int) callconv(.c) void {
     // Stop the run loop to allow graceful shutdown with defer statements
     c.CFRunLoopStop(c.CFRunLoopGetCurrent());
 }
@@ -699,7 +698,7 @@ pub fn reloadConfig(self: *Skhd) !void {
     parser.parseWithPath(&new_mappings, content, self.config_file) catch |err| {
         // Log the parse error with proper formatting
         if (parser.error_info) |parse_err| {
-            log.err("skhd: {}", .{parse_err});
+            log.err("skhd: {f}", .{parse_err});
         }
         return err;
     };

--- a/src/synthesize.zig
+++ b/src/synthesize.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const c = @import("c.zig");
+const c = @import("c.zig").c_impl;
 const Parser = @import("Parser.zig");
 const Mappings = @import("Mappings.zig");
 const Hotkey = @import("Hotkey.zig");
@@ -96,7 +96,7 @@ pub fn synthesizeText(allocator: std.mem.Allocator, text: []const u8) !void {
         c.CGEventPost(c.kCGAnnotatedSessionEventTap, down_event);
 
         // Small delay between key down and up
-        std.time.sleep(1000 * 1000); // 1ms in nanoseconds
+        std.Thread.sleep(1000 * 1000); // 1ms in nanoseconds
 
         c.CGEventKeyboardSetUnicodeString(up_event, 1, &char);
         c.CGEventPost(c.kCGAnnotatedSessionEventTap, up_event);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -546,13 +546,13 @@ test "Parser error message formatting" {
     var err1 = try ParseError.fromPosition(testing.allocator, 5, 10, "Test error message", null);
     defer err1.deinit();
     var buf: [256]u8 = undefined;
-    const result1 = try std.fmt.bufPrint(&buf, "{}", .{err1});
+    const result1 = try std.fmt.bufPrint(&buf, "{f}", .{err1});
     try testing.expectEqualStrings("5:10: error: Test error message", result1);
 
     // Test error formatting with file path
     var err2 = try ParseError.fromPosition(testing.allocator, 3, 7, "Another error", "test.skhdrc");
     defer err2.deinit();
-    const result2 = try std.fmt.bufPrint(&buf, "{}", .{err2});
+    const result2 = try std.fmt.bufPrint(&buf, "{f}", .{err2});
     try testing.expectEqualStrings("test.skhdrc:3:7: error: Another error", result2);
 
     // Test error with token text
@@ -564,7 +564,7 @@ test "Parser error message formatting" {
     };
     var err3 = try ParseError.fromToken(testing.allocator, token, "Unknown key", "config.skhdrc");
     defer err3.deinit();
-    const result3 = try std.fmt.bufPrint(&buf, "{}", .{err3});
+    const result3 = try std.fmt.bufPrint(&buf, "{f}", .{err3});
     try testing.expectEqualStrings("config.skhdrc:2:15: error: Unknown key near 'badkey'", result3);
 }
 
@@ -1789,7 +1789,7 @@ test "mode activation with process groups" {
 
 test "NX media key forwarding" {
     const allocator = std.testing.allocator;
-    const c = @import("c.zig");
+    const c = @import("c.zig").c_impl;
 
     // Test forwarding regular key to NX media key
     const config =

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -21,7 +21,7 @@ pub fn indentPrint(alloc: std.mem.Allocator, writer: anytype, padding: []const u
 
 test {
     const alloc = std.testing.allocator;
-    var list = std.ArrayList(u8).init(alloc);
+    var list = std.array_list.Managed(u8).init(alloc);
     defer list.deinit();
     const writer = list.writer();
 


### PR DESCRIPTION
Zig 0.15 introduces several breaking API changes that prevent this project from building. This PR addresses all of them.

**Breaking:** Zig 0.14 and earlier are no longer supported.

**Build system**
- `build.zig.zon`: set `minimum_zig_version = "0.15.0"`
- `build.zig`: `addExecutable`/`addTest` now use `root_module` + `b.createModule()` — the top-level `root_source_file` field was removed in 0.15
- Benchmark step disabled: zbench is not yet compatible with Zig 0.15

**C import**
- `c.zig`: `pub usingnamespace @cImport(...)` → `pub const c_impl = @cImport(...)` — re-exporting `usingnamespace` is no longer allowed
- All call sites updated to use `@import("c.zig").c_impl`; `NSApplicationLoad` accessed via `@import("c.zig").NSApplicationLoad()`

**Stdlib / language**
- `std.ArrayList` → `std.array_list.Managed`
- `std.time.sleep` → `std.Thread.sleep`
- `stderr.reader()` / `.writer()` → `.deprecatedReader()` / `.deprecatedWriter()`
- `std.posix.empty_sigset` → `std.posix.sigemptyset()`
- `callconv(.C)` → `callconv(.c)`

**Format protocol**
- Custom `format` methods updated to: `format(self, writer: anytype) !void` — `comptime fmt` and `FormatOptions` parameters removed in 0.15
- Call sites that invoke the format method use `{f}` specifier
- `Mappings.format` and `Mode.format` rewritten without allocation to match the `error{WriteFailed}!void` error set required by `{f}`

**CI**
- Both jobs updated from Zig `0.14.0` to `0.15.2`

### Testing

Tested on macOS 26.3.1 (arm64) with Zig 0.15.2:

- `zig build test` — all tests pass
- `zig build -Doptimize=ReleaseFast` — succeeds
- `./zig-out/bin/skhd --version` — binary runs correctly
- Ran as the active `skhd` daemon with an existing `.skhdrc` — hotkeys work