### PR TITLE
Tahoe compatibility: .app bundle, daemon-startup retries, launchd & log fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,28 @@ jobs:
     
     - name: Run tests
       run: zig build test
-    
+
     - name: Build Debug
       run: zig build
-    
+
     - name: Check version
       run: ./zig-out/bin/skhd --version
+
+    - name: Build .app bundle
+      run: zig build app
+
+    - name: Verify bundle layout
+      # The release pipeline ships skhd.app, so any regression in
+      # scripts/make-app.sh or assets/Info.plist.template must fail at
+      # PR time, not at tag time.
+      run: |
+        test -f zig-out/skhd.app/Contents/MacOS/skhd
+        test -f zig-out/skhd.app/Contents/Info.plist
+        grep -q "<string>com.jackielii.skhd</string>" zig-out/skhd.app/Contents/Info.plist
+        plutil -lint zig-out/skhd.app/Contents/Info.plist
+
+    - name: Lint shell scripts
+      run: bash -n scripts/make-app.sh && bash -n scripts/codesign.sh && bash -n scripts/release.sh
 
   build-all:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,11 @@ jobs:
         CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
         KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
 
-        # Import certificate if available
+        # Import certificate if available; otherwise hard-fail. Tagged releases
+        # without skhd-cert produce adhoc-signed bundles that silently lose
+        # TCC accessibility permissions on every install/upgrade — never the
+        # right outcome for a public release. Override only by setting
+        # ALLOW_UNSIGNED_RELEASE=true in the workflow env.
         if [ -n "$CERTIFICATE_P12" ]; then
           echo "Certificate found, setting up code signing..."
 
@@ -97,9 +101,15 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
           echo "SHOULD_SIGN=true" >> $GITHUB_ENV
-        else
-          echo "No certificate found, skipping code signing (binaries will use adhoc signature)"
+        elif [ "${ALLOW_UNSIGNED_RELEASE:-false}" = "true" ]; then
+          echo "::warning::ALLOW_UNSIGNED_RELEASE=true — shipping adhoc-signed bundles."
+          echo "::warning::Tahoe users will lose accessibility permissions on this release."
           echo "SHOULD_SIGN=false" >> $GITHUB_ENV
+        else
+          echo "::error::MACOS_CERTIFICATE secret is not configured."
+          echo "::error::Tagged releases require code signing — see docs/CODE_SIGNING.md."
+          echo "::error::Set ALLOW_UNSIGNED_RELEASE=true in this workflow's env to opt out (not recommended)."
+          exit 1
         fi
 
     - name: Build Release .app bundle
@@ -179,19 +189,28 @@ jobs:
         echo "x86_64_sha=${X86_64_SHA}" >> $GITHUB_OUTPUT
 
     - name: Update Formula
+      env:
+        VERSION: ${{ steps.release.outputs.version }}
+        ARM64_SHA: ${{ steps.release.outputs.arm64_sha }}
+        X86_64_SHA: ${{ steps.release.outputs.x86_64_sha }}
       run: |
         cd homebrew-tap
-        
-        # Update version
-        sed -i "s/version \".*\"/version \"${{ steps.release.outputs.version }}\"/" Formula/skhd-zig.rb
-        
-        # Update URLs
-        sed -i "s|download/v[0-9.(-preview)]\+/skhd-x86_64|download/v${{ steps.release.outputs.version }}/skhd-x86_64|" Formula/skhd-zig.rb
-        sed -i "s|download/v[0-9.(-preview)]\+/skhd-arm64|download/v${{ steps.release.outputs.version }}/skhd-arm64|" Formula/skhd-zig.rb
-        
-        # Update SHA256
-        sed -i "/x86_64-macos.tar.gz/,/sha256/ s/sha256 \".*\"/sha256 \"${{ steps.release.outputs.x86_64_sha }}\"/" Formula/skhd-zig.rb
-        sed -i "/arm64-macos.tar.gz/,/sha256/ s/sha256 \".*\"/sha256 \"${{ steps.release.outputs.arm64_sha }}\"/" Formula/skhd-zig.rb
+
+        # Update version line if present (the formula may scan version from
+        # URL instead). No-op when missing.
+        sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/skhd-zig.rb
+
+        # Update URLs. Match v<digits-and-dots> with an optional pre-release
+        # suffix (-preview, -rc1, etc.). Use ERE with -E so the alternation
+        # syntax is sane; the previous BRE character class
+        # `[0-9.(-preview)]\+` accidentally allowed any of those literal
+        # characters and only worked for plain semver tags.
+        sed -i -E "s|download/v[0-9.]+(-[A-Za-z0-9]+)?/skhd-x86_64|download/v${VERSION}/skhd-x86_64|" Formula/skhd-zig.rb
+        sed -i -E "s|download/v[0-9.]+(-[A-Za-z0-9]+)?/skhd-arm64|download/v${VERSION}/skhd-arm64|" Formula/skhd-zig.rb
+
+        # Update each architecture's sha256 (range from URL line to next sha256 line).
+        sed -i "/x86_64-macos.tar.gz/,/sha256/ s/sha256 \".*\"/sha256 \"${X86_64_SHA}\"/" Formula/skhd-zig.rb
+        sed -i "/arm64-macos.tar.gz/,/sha256/ s/sha256 \".*\"/sha256 \"${ARM64_SHA}\"/" Formula/skhd-zig.rb
 
     - name: Commit and push
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,33 +102,25 @@ jobs:
           echo "SHOULD_SIGN=false" >> $GITHUB_ENV
         fi
 
-    - name: Build Release (binary + .app bundle)
+    - name: Build Release .app bundle
       run: |
-        zig build -Doptimize=ReleaseFast
         zig build app -Doptimize=ReleaseFast
-        # Stage release artifacts at the working tree root for tarballing.
-        mv zig-out/bin/skhd skhd-${{ matrix.arch }}-macos
-        mv zig-out/skhd.app skhd-${{ matrix.arch }}-macos.app
+        # Stage the bundle at the working tree root for tarballing.
+        mv zig-out/skhd.app skhd.app
 
-    - name: Code Sign Binary and Bundle
+    - name: Code Sign Bundle
       if: env.SHOULD_SIGN == 'true'
       run: |
-        # Sign the bare binary (kept for users who only need CLI invocation).
-        codesign -f -s "skhd-cert" -i com.jackielii.skhd skhd-${{ matrix.arch }}-macos
-        codesign -dv skhd-${{ matrix.arch }}-macos
-        # Sign the bundle: inner Mach-O first, then the bundle layer.
-        codesign -f -s "skhd-cert" -i com.jackielii.skhd \
-          skhd-${{ matrix.arch }}-macos.app/Contents/MacOS/skhd
-        codesign -f -s "skhd-cert" -i com.jackielii.skhd \
-          skhd-${{ matrix.arch }}-macos.app
-        codesign -dv --verbose=2 skhd-${{ matrix.arch }}-macos.app
+        # Sign inner Mach-O first, then the bundle layer.
+        codesign -f -s "skhd-cert" -i com.jackielii.skhd skhd.app/Contents/MacOS/skhd
+        codesign -f -s "skhd-cert" -i com.jackielii.skhd skhd.app
+        codesign -dv --verbose=2 skhd.app
 
     - name: Create tarball
       run: |
-        # Ship both the bare binary tarball (back-compat for source-style
-        # installs) and the .app bundle tarball (the supported Tahoe path).
-        tar -czf skhd-${{ matrix.arch }}-macos.tar.gz skhd-${{ matrix.arch }}-macos
-        tar -czf skhd-${{ matrix.arch }}-macos-app.tar.gz skhd-${{ matrix.arch }}-macos.app
+        # Tarball name kept identical to pre-bundle releases so the homebrew
+        # formula auto-bump regex still matches; content is now skhd.app/.
+        tar -czf skhd-${{ matrix.arch }}-macos.tar.gz skhd.app
 
     - name: Cleanup Keychain
       if: always() && env.SHOULD_SIGN == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,13 +127,12 @@ jobs:
       run: |
         security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
     
-    - name: Upload Release Assets
+    - name: Upload Release Asset
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release upload ${{ github.ref_name }} \
           ./skhd-${{ matrix.arch }}-macos.tar.gz \
-          ./skhd-${{ matrix.arch }}-macos-app.tar.gz \
           --repo ${{ github.repository }} \
           --clobber
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,32 +102,46 @@ jobs:
           echo "SHOULD_SIGN=false" >> $GITHUB_ENV
         fi
 
-    - name: Build Release
+    - name: Build Release (binary + .app bundle)
       run: |
         zig build -Doptimize=ReleaseFast
+        zig build app -Doptimize=ReleaseFast
+        # Stage release artifacts at the working tree root for tarballing.
         mv zig-out/bin/skhd skhd-${{ matrix.arch }}-macos
+        mv zig-out/skhd.app skhd-${{ matrix.arch }}-macos.app
 
-    - name: Code Sign Binary
+    - name: Code Sign Binary and Bundle
       if: env.SHOULD_SIGN == 'true'
       run: |
+        # Sign the bare binary (kept for users who only need CLI invocation).
         codesign -f -s "skhd-cert" -i com.jackielii.skhd skhd-${{ matrix.arch }}-macos
         codesign -dv skhd-${{ matrix.arch }}-macos
+        # Sign the bundle: inner Mach-O first, then the bundle layer.
+        codesign -f -s "skhd-cert" -i com.jackielii.skhd \
+          skhd-${{ matrix.arch }}-macos.app/Contents/MacOS/skhd
+        codesign -f -s "skhd-cert" -i com.jackielii.skhd \
+          skhd-${{ matrix.arch }}-macos.app
+        codesign -dv --verbose=2 skhd-${{ matrix.arch }}-macos.app
 
     - name: Create tarball
       run: |
+        # Ship both the bare binary tarball (back-compat for source-style
+        # installs) and the .app bundle tarball (the supported Tahoe path).
         tar -czf skhd-${{ matrix.arch }}-macos.tar.gz skhd-${{ matrix.arch }}-macos
+        tar -czf skhd-${{ matrix.arch }}-macos-app.tar.gz skhd-${{ matrix.arch }}-macos.app
 
     - name: Cleanup Keychain
       if: always() && env.SHOULD_SIGN == 'true'
       run: |
         security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
     
-    - name: Upload Release Asset
+    - name: Upload Release Assets
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release upload ${{ github.ref_name }} \
           ./skhd-${{ matrix.arch }}-macos.tar.gz \
+          ./skhd-${{ matrix.arch }}-macos-app.tar.gz \
           --repo ${{ github.repository }} \
           --clobber
 

--- a/README.md
+++ b/README.md
@@ -16,19 +16,25 @@ The easiest way to install skhd.zig:
 brew install jackielii/tap/skhd-zig
 ```
 
+> Upgrading from 0.0.17 or earlier? See [docs/UPGRADING.md](docs/UPGRADING.md). The 0.0.18 release switches to an `.app` bundle to keep accessibility permissions working on macOS Tahoe; one-time re-grant is required.
+
 ### Pre-built Binaries
 
 Download the latest release for your architecture:
 
-- `skhd-arm64-macos.tar.gz` - For Apple Silicon Macs
-- `skhd-x86_64-macos.tar.gz` - For Intel Macs
+- `skhd-arm64-macos.tar.gz` - For Apple Silicon Macs (contains `skhd.app`)
+- `skhd-x86_64-macos.tar.gz` - For Intel Macs (contains `skhd.app`)
 
 Extract and install:
 
 ```bash
 tar -xzf skhd-*.tar.gz
-sudo cp skhd /usr/local/bin/
+mv skhd.app /Applications/
+# Optional: expose the CLI on your PATH
+sudo ln -sfn /Applications/skhd.app/Contents/MacOS/skhd /usr/local/bin/skhd
 ```
+
+Then grant accessibility (see [Granting Accessibility](#granting-accessibility) below).
 
 ### Development Builds from GitHub Actions
 
@@ -50,12 +56,29 @@ If you need builds with different optimization levels (Debug, ReleaseSafe, Relea
 git clone https://github.com/jackielii/skhd.zig
 cd skhd.zig
 
-# Build in release mode
-zig build -Doptimize=ReleaseFast
+# Build the .app bundle and code-sign it
+# (required for Accessibility to persist on macOS Tahoe / Sequoia)
+zig build sign-app -Doptimize=ReleaseFast
 
-# Install (copy to /usr/local/bin)
-sudo cp zig-out/bin/skhd /usr/local/bin/
+# Install: symlink the bundle into /Applications, expose the CLI
+ln -sfn "$(pwd)/zig-out/skhd.app" /Applications/skhd.app
+sudo ln -sfn /Applications/skhd.app/Contents/MacOS/skhd /usr/local/bin/skhd
 ```
+
+For quick dev iteration without the bundle wrapper, `zig build` still produces a bare binary at `zig-out/bin/skhd`. The `.app` is only needed for the System Settings → Accessibility picker.
+
+The first run of `zig build sign-app` creates a self-signed `skhd-cert` certificate in your login keychain. See [docs/CODE_SIGNING.md](docs/CODE_SIGNING.md) for details and troubleshooting.
+
+### Granting Accessibility
+
+skhd captures keyboard events via macOS Core Graphics, which requires Accessibility permission:
+
+1. Open **System Settings → Privacy & Security → Accessibility**
+2. Click **`+`**, navigate to `/Applications/skhd.app`, add it
+3. Toggle the entry on
+4. Run `skhd --restart-service` (or `skhd --start-service` if not yet running)
+
+You only need to do this once. The bundle's stable identifier (`com.jackielii.skhd`) means TCC entries persist across rebuilds and `brew upgrade`.
 
 ## Running as Service
 
@@ -81,7 +104,7 @@ skhd --uninstall-service
 
 The service will:
 - Start automatically on login
-- Create logs at `/tmp/skhd_$USER.log`
+- Write logs to `~/Library/Logs/skhd.log`
 - Use your config from `~/.config/skhd/skhdrc` or `~/.skhdrc`
 - Automatically reload on config changes
 
@@ -124,8 +147,9 @@ The service will:
 - `--start-service` - Start as service
 - `--restart-service` - Restart service
 - `--stop-service` - Stop service
+- `--status` - Daemon health (PID + event-tap status)
 - PID file management (`/tmp/skhd_$USER.pid`)
-- Service logging (`/tmp/skhd_$USER.log`)
+- Service logging (`~/Library/Logs/skhd.log`)
 
 ### Advanced Features
 

--- a/assets/Info.plist.template
+++ b/assets/Info.plist.template
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.jackielii.skhd</string>
+    <key>CFBundleName</key>
+    <string>skhd</string>
+    <key>CFBundleDisplayName</key>
+    <string>skhd</string>
+    <key>CFBundleExecutable</key>
+    <string>skhd</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleVersion</key>
+    <string>__VERSION__</string>
+    <key>CFBundleShortVersionString</key>
+    <string>__VERSION__</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>LSBackgroundOnly</key>
+    <true/>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>Released under the MIT License.</string>
+</dict>
+</plist>

--- a/build.zig
+++ b/build.zig
@@ -86,9 +86,11 @@ pub fn build(b: *std.Build) void {
     // Accessibility picker accepts it and TCC keys entries by bundle ID
     // (com.jackielii.skhd) instead of by the binary's path. Inner binary at
     // skhd.app/Contents/MacOS/skhd is a copy, not a symlink, so codesigning
-    // works.
+    // works. Scripts have bash shebangs and use bash-only `[[ ... ]]` syntax,
+    // so invoke via bash explicitly (`/bin/sh` may not be bash on every
+    // system that runs `zig build`).
     const app_cmd = b.addSystemCommand(&[_][]const u8{
-        "sh",
+        "bash",
         "scripts/make-app.sh",
     });
     app_cmd.addArg(installed_exe);
@@ -98,28 +100,29 @@ pub fn build(b: *std.Build) void {
     const app_step = b.step("app", "Build the skhd.app bundle wrapper");
     app_step.dependOn(&app_cmd.step);
 
-    // Code signing. Passing the .app bundle signs both the inner Mach-O and
-    // the bundle; passing the bare binary signs just it. Default to .app when
-    // it exists so users iterating with `zig build app && zig build sign` get
-    // a properly-signed bundle.
+    // Code signing.
+    //   `zig build sign`     - signs the bare binary at zig-out/bin/skhd.
+    //   `zig build sign-app` - signs the .app bundle (inner Mach-O + bundle
+    //                          layer); use this after `zig build app` for
+    //                          Tahoe-compatible installs.
     const sign_cmd = b.addSystemCommand(&[_][]const u8{
-        "sh",
+        "bash",
         "scripts/codesign.sh",
     });
     sign_cmd.addArg(installed_exe);
     sign_cmd.step.dependOn(b.getInstallStep());
 
-    const sign_step = b.step("sign", "Code sign the binary (required for accessibility permissions on macOS 15+)");
+    const sign_step = b.step("sign", "Code sign the bare binary");
     sign_step.dependOn(&sign_cmd.step);
 
     const sign_app_cmd = b.addSystemCommand(&[_][]const u8{
-        "sh",
+        "bash",
         "scripts/codesign.sh",
     });
     sign_app_cmd.addArg(installed_app);
     sign_app_cmd.step.dependOn(&app_cmd.step);
 
-    const sign_app_step = b.step("sign-app", "Build and code sign the skhd.app bundle");
+    const sign_app_step = b.step("sign-app", "Build and code sign the skhd.app bundle (Tahoe-compatible)");
     sign_app_step.dependOn(&sign_app_cmd.step);
 
     const test_step = b.step("test", "Run unit tests");

--- a/build.zig
+++ b/build.zig
@@ -79,17 +79,48 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    // Code signing step
+    const installed_exe = b.getInstallPath(.bin, exe.name);
+    const installed_app = b.getInstallPath(.prefix, "skhd.app");
+
+    // .app bundle step. Wraps the binary into skhd.app so macOS Tahoe's
+    // Accessibility picker accepts it and TCC keys entries by bundle ID
+    // (com.jackielii.skhd) instead of by the binary's path. Inner binary at
+    // skhd.app/Contents/MacOS/skhd is a copy, not a symlink, so codesigning
+    // works.
+    const app_cmd = b.addSystemCommand(&[_][]const u8{
+        "sh",
+        "scripts/make-app.sh",
+    });
+    app_cmd.addArg(installed_exe);
+    app_cmd.addArg(installed_app);
+    app_cmd.step.dependOn(b.getInstallStep());
+
+    const app_step = b.step("app", "Build the skhd.app bundle wrapper");
+    app_step.dependOn(&app_cmd.step);
+
+    // Code signing. Passing the .app bundle signs both the inner Mach-O and
+    // the bundle; passing the bare binary signs just it. Default to .app when
+    // it exists so users iterating with `zig build app && zig build sign` get
+    // a properly-signed bundle.
     const sign_cmd = b.addSystemCommand(&[_][]const u8{
         "sh",
         "scripts/codesign.sh",
     });
-    const installed_exe = b.getInstallPath(.bin, exe.name);
     sign_cmd.addArg(installed_exe);
     sign_cmd.step.dependOn(b.getInstallStep());
 
     const sign_step = b.step("sign", "Code sign the binary (required for accessibility permissions on macOS 15+)");
     sign_step.dependOn(&sign_cmd.step);
+
+    const sign_app_cmd = b.addSystemCommand(&[_][]const u8{
+        "sh",
+        "scripts/codesign.sh",
+    });
+    sign_app_cmd.addArg(installed_app);
+    sign_app_cmd.step.dependOn(&app_cmd.step);
+
+    const sign_app_step = b.step("sign-app", "Build and code sign the skhd.app bundle");
+    sign_app_step.dependOn(&sign_app_cmd.step);
 
     const test_step = b.step("test", "Run unit tests");
 

--- a/docs/CODE_SIGNING.md
+++ b/docs/CODE_SIGNING.md
@@ -1,53 +1,60 @@
-# Code Signing for Accessibility Permissions
+# Code Signing & .app Bundle for Accessibility Permissions
 
-## Why Code Signing is Required
+## Why Both Are Required
 
-Starting with macOS 15 (Sequoia) and especially macOS 26 (Tahoe) released in September 2025, **code signing with a stable identity is required** for accessibility permissions to persist across builds.
+Starting with macOS 15 (Sequoia) and especially macOS 26 (Tahoe) released in September 2025, **two things are required for accessibility permissions to behave well**:
 
-### The Problem
+1. **Code signing with a stable identity** — so TCC (Transparency, Consent, Control) recognizes the binary across rebuilds.
+2. **An `.app` bundle wrapper** — so the System Settings → Accessibility picker accepts the binary, and so TCC keys the entry by bundle identifier (`com.jackielii.skhd`) instead of by file path.
 
-- **macOS TCC (Transparency, Consent, and Control)** uses code signatures to track accessibility permissions
-- Adhoc signatures (Zig's default) cause macOS to treat each build as a "different" binary
-- **CVE-2025-43312**: Unsigned services are now blocked from launching on Intel Macs
-- This results in constant permission resets and "ACCESSIBILITY PERMISSIONS REQUIRED" warnings
+### What goes wrong without these
+
+- **Without a stable signature** (Zig's default adhoc signing): every rebuild looks like a "different" binary to TCC, permissions reset, you keep seeing "ACCESSIBILITY PERMISSIONS REQUIRED".
+- **Without the `.app` bundle** (bare Mach-O): on macOS Tahoe the Accessibility `+` picker silently rejects the binary; the entry never appears in the list. TCC entries that *do* get created are path-based (`client_type=1`) and break on `brew upgrade` because the Cellar version path changes.
+- **CVE-2025-43312**: Unsigned services are now blocked from launching on Intel Macs.
 
 ### The Solution
 
-Use a **self-signed code signing certificate** with a stable identity (bundle identifier: `com.jackielii.skhd`) to ensure TCC recognizes the binary across rebuilds.
+Use a **self-signed code signing certificate** (`skhd-cert`) with a stable bundle identifier (`com.jackielii.skhd`), AND wrap the binary in an `.app` bundle. The combination produces TCC entries keyed by bundle ID that survive both rebuilds and Homebrew version upgrades.
 
 ## Setting Up Code Signing
 
 ### 1. Create a Self-Signed Certificate (One-Time Setup)
 
+`zig build sign` will try to create the cert automatically via `openssl` + `security import`. If that fails (e.g. on some keychain configurations), create it by hand in Keychain Access:
+
 ```bash
-# Open Keychain Access
 open "/Applications/Utilities/Keychain Access.app"
 ```
 
-Then in Keychain Access:
+Then:
 1. Menu: **Keychain Access** → **Certificate Assistant** → **Create a Certificate**
 2. Name: `skhd-cert`
 3. Identity Type: **Self-Signed Root**
 4. Certificate Type: **Code Signing**
 5. Click **Create**
 
-### 2. Build and Sign
+### 2. Build, Bundle, and Sign
 
 ```bash
-# Build the project
+# Build the bare binary (development iteration)
 zig build
 
-# Sign the binary
-zig build sign
+# Build skhd.app + sign both the inner Mach-O and the bundle
+zig build sign-app
 
-# Alternatively, use the script directly:
-./scripts/codesign.sh ./zig-out/bin/skhd
+# Equivalent to:
+zig build app                          # produces zig-out/skhd.app
+./scripts/codesign.sh zig-out/skhd.app # signs both layers
 ```
 
 ### 3. Grant Accessibility Permissions
 
-1. Run skhd: `./zig-out/bin/skhd`
-2. Go to: **System Settings** → **Privacy & Security** → **Accessibility**
+1. Move or symlink the bundle into `/Applications` (Tahoe's picker prefers paths there):
+   ```bash
+   ln -sfn "$(pwd)/zig-out/skhd.app" /Applications/skhd.app
+   ```
+2. Open: **System Settings** → **Privacy & Security** → **Accessibility**
 3. Enable the checkbox next to `skhd`
 4. Restart skhd
 
@@ -57,28 +64,32 @@ Permissions will now **persist across rebuilds** as long as you sign each new bu
 
 ## Verifying Code Signature
 
-Check the signature status:
-
 ```bash
-codesign -dv ./zig-out/bin/skhd
+codesign -dv --verbose=2 ./zig-out/skhd.app
 ```
 
 Expected output with proper signing:
 ```
-Executable=/path/to/skhd
+Executable=/path/to/zig-out/skhd.app/Contents/MacOS/skhd
 Identifier=com.jackielii.skhd
-Format=Mach-O thin (arm64)
-CodeDirectory v=20400 size=XXXX flags=0x0(none) hashes=XXX+0 location=embedded
-Signature size=XXXX
+Format=app bundle with Mach-O thin (arm64)
 Authority=skhd-cert
 Signed Time=...
-Info.plist=not bound
 TeamIdentifier=not set
+Sealed Resources version=2 ...
 ```
 
-Key differences from adhoc signature:
+Key things to confirm:
+- `Format=app bundle with Mach-O thin (arm64)` — proves the bundle layer is signed, not just the inner binary
 - `Authority=skhd-cert` (not "adhoc")
 - `Identifier=com.jackielii.skhd` (stable bundle ID)
+
+You can also verify TCC has bundle-ID-keyed entries (rather than path-keyed):
+```bash
+sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+  "SELECT service, client, client_type FROM access WHERE client='com.jackielii.skhd';"
+```
+Look for rows with `client_type=0` (bundle ID) — those are the entries that survive rebuilds and `brew upgrade`.
 
 ## CI/CD Compatibility
 
@@ -100,13 +111,37 @@ For users installing via Homebrew:
 
 This is normal - click **Always Allow** to avoid repeated prompts.
 
+### Permissions stop working after replacing the binary in-place
+
+If you `cp` a freshly-built binary on top of an existing path (e.g. into `/opt/homebrew/Cellar/skhd-zig/<ver>/...`), TCC may invalidate the previously-granted entry because the on-disk code signature stops matching the stored requirement (`csreq`). The entry stays in the table with `auth_value=2` but the daemon reports "not granted".
+
+Two ways to recover:
+
+1. **Use the .app bundle approach** (recommended): bundle-ID-keyed TCC entries (`client_type=0`) survive in-place replacements as long as the new binary keeps the same `Identifier` (`com.jackielii.skhd`) and signing certificate. This is why `zig build sign-app` is the right local workflow.
+
+2. **Drop and re-grant**: if you have a stale path-keyed entry blocking re-add, delete it directly:
+   ```bash
+   sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+     "DELETE FROM access WHERE client LIKE '%skhd%' AND client_type=1;"
+   ```
+   Then restart skhd and grant fresh.
+
+### "skhd doesn't appear in the Accessibility list"
+
+On macOS Tahoe the Accessibility picker silently rejects bare Mach-O binaries. You need the `.app` bundle. Build with `zig build sign-app`, symlink it into `/Applications`, and add `/Applications/skhd.app` (not the inner binary) in System Settings.
+
+### `--status` says "Not granted" even though the daemon works
+
+`AXIsProcessTrusted()` checks the *responsible* process, which for terminal-launched commands is the terminal, not skhd. The launchd-spawned daemon is the one whose permissions matter — check `launchctl list | grep com.jackielii.skhd` for a non-zero PID, and the log at `~/Library/Logs/skhd.log` for `Event tap created successfully`.
+
 ### Permissions still reset after signing
 
-1. Verify the signature: `codesign -dv ./zig-out/bin/skhd`
+1. Verify the signature: `codesign -dv --verbose=2 ./zig-out/skhd.app`
 2. Check that `Authority=skhd-cert` (not "adhoc")
-3. Check that `Identifier=com.jackielii.skhd` is present
-4. Remove old accessibility permissions and re-add
-5. Ensure you're signing with the same certificate each time
+3. Check that `Format=app bundle with Mach-O thin (...)` — bundle layer is signed
+4. Check that `Identifier=com.jackielii.skhd` is present
+5. Remove old accessibility entries (especially path-keyed ones) and re-add
+6. Ensure you're signing with the same certificate each time
 
 ### Certificate not found when running `zig build sign`
 

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,0 +1,112 @@
+# Upgrading to skhd.zig 0.0.18 (macOS Tahoe compatibility)
+
+Version 0.0.18 ships with a wholesale rework of how skhd integrates with macOS, in response to a series of issues that surfaced on macOS 26 (Tahoe). If you are upgrading from 0.0.17 or earlier, please read the **Required actions** section before installing.
+
+## What changed and why
+
+| Area | Before | After |
+|---|---|---|
+| Distribution layout | bare Mach-O at `bin/skhd` | `.app` bundle (`skhd.app/Contents/MacOS/skhd`) with bare-binary symlink kept for CLI use |
+| TCC entries | path-keyed (`/opt/homebrew/Cellar/.../bin/skhd`) | bundle-ID-keyed (`com.jackielii.skhd`) |
+| LaunchAgent commands | `launchctl load -w` / `unload -w` | `launchctl bootstrap` / `bootout` (no persistent disable flag) |
+| Plist `ProgramArguments` | version-pinned Cellar path | stable `/opt/homebrew/opt/skhd-zig/...` symlink |
+| Plist log path | `/tmp/skhd_$USER.log` (wiped at boot) | `~/Library/Logs/skhd.log` |
+| Plist `ThrottleInterval` | 30 s | 10 s |
+| `CGEventTapCreate` failures | exit immediately, wait full throttle, repeat | retry up to 10× at 500 ms before giving up |
+
+The combined effect: the daemon comes up reliably after a cold reboot, accessibility permissions persist across `brew upgrade` and rebuilds, and a previous `--stop-service` no longer prevents auto-load on the next login.
+
+## Required actions
+
+These steps assume you installed the previous version via Homebrew. The order matters.
+
+### 1. Stop the old service
+
+```bash
+skhd --stop-service
+```
+
+### 2. Upgrade
+
+```bash
+brew upgrade jackielii/tap/skhd-zig
+```
+
+The new formula installs `skhd.app` to `<prefix>/skhd.app`, symlinks the CLI into `bin/skhd`, and creates `/Applications/skhd.app` so macOS Settings can find it.
+
+### 3. Clear the legacy disable flag (if you ever ran the old `--stop-service`)
+
+The old `unload -w` set a flag in launchd's persistent disable list. The new `--start-service` clears it automatically, but it's worth confirming it's gone:
+
+```bash
+launchctl print-disabled gui/$(id -u) | grep com.jackielii.skhd
+# Expect: "com.jackielii.skhd" => enabled
+```
+
+If it shows `disabled`, run:
+```bash
+launchctl enable gui/$(id -u)/com.jackielii.skhd
+```
+
+### 4. Drop stale TCC entries from previous installs
+
+The path-keyed accessibility entries from previous Cellar versions will silently shadow the new bundle-ID entry until removed:
+
+```bash
+sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" \
+  "DELETE FROM access WHERE client LIKE '%skhd-zig%' AND client_type=1;"
+```
+
+This deletes only path-keyed (`client_type=1`) rows. The new bundle-ID-keyed (`client_type=0`) entry created when you grant in step 6 below is left untouched on future runs.
+
+### 5. Install the new LaunchAgent plist
+
+```bash
+skhd --install-service
+```
+
+The plist now points at `/opt/homebrew/opt/skhd-zig/skhd.app/Contents/MacOS/skhd` (stable across `brew upgrade`).
+
+### 6. Grant Accessibility for `skhd.app`
+
+1. Open **System Settings → Privacy & Security → Accessibility**
+2. Click `+`, navigate to `/Applications/skhd.app`, add it
+3. Toggle the entry on
+
+You will only need to do this once. The bundle-ID-keyed TCC entry now persists across rebuilds and Homebrew upgrades.
+
+### 7. Start
+
+```bash
+skhd --start-service
+```
+
+Watch the log at `~/Library/Logs/skhd.log`. You should see:
+
+```
+info(skhd): Starting event tap
+info(skhd): Event tap created successfully. skhd is now running.
+```
+
+Or if the daemon hits the early-boot `WindowServer` race once or twice, the new retry loop handles it:
+```
+warning(event_tap): Event tap creation failed (attempt 1/10), retrying in 500ms...
+info(event_tap): Event tap created on attempt 2/10
+```
+
+## Notes for source builds
+
+If you build from source rather than installing via Homebrew:
+
+```bash
+zig build sign-app                          # produces a signed zig-out/skhd.app
+ln -sfn "$(pwd)/zig-out/skhd.app" /Applications/skhd.app
+/Applications/skhd.app/Contents/MacOS/skhd --install-service
+/Applications/skhd.app/Contents/MacOS/skhd --start-service
+```
+
+`zig build` (without `app`) still produces the bare binary at `zig-out/bin/skhd` for quick development iteration — it just won't be visible in the Accessibility picker.
+
+## Troubleshooting
+
+If anything goes sideways, see [docs/CODE_SIGNING.md](CODE_SIGNING.md) — the troubleshooting section there covers stale TCC entries, picker rejections, the misleading `--status` output, and signing problems.

--- a/scripts/codesign.sh
+++ b/scripts/codesign.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Configuration
-BINARY_PATH="${1:-./zig-out/bin/skhd}"
+TARGET_PATH="${1:-./zig-out/bin/skhd}"
 CERT_NAME="${SKHD_CERT:-skhd-cert}"
 BUNDLE_ID="com.jackielii.skhd"
 
@@ -12,12 +12,22 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-echo "Code signing skhd binary..."
+echo "Code signing skhd..."
 
-# Check if binary exists
-if [ ! -f "$BINARY_PATH" ]; then
-    echo -e "${RED}Error: Binary not found at $BINARY_PATH${NC}"
-    echo "Build the project first: zig build"
+# Resolve target: accept either a bare Mach-O binary or a .app bundle.
+if [ -d "$TARGET_PATH" ] && [[ "$TARGET_PATH" == *.app ]]; then
+    APP_PATH="$TARGET_PATH"
+    INNER_BINARY="$APP_PATH/Contents/MacOS/skhd"
+    if [ ! -f "$INNER_BINARY" ]; then
+        echo -e "${RED}Error: $APP_PATH does not contain Contents/MacOS/skhd${NC}"
+        exit 1
+    fi
+elif [ -f "$TARGET_PATH" ]; then
+    APP_PATH=""
+    INNER_BINARY="$TARGET_PATH"
+else
+    echo -e "${RED}Error: $TARGET_PATH not found (expected a binary or a .app bundle)${NC}"
+    echo "Build the project first: zig build (or zig build app)"
     exit 1
 fi
 
@@ -27,35 +37,55 @@ if ! security find-certificate -c "$CERT_NAME" ~/Library/Keychains/login.keychai
     echo "Creating self-signed code signing certificate..."
     echo ""
 
-    # Try to create the certificate programmatically
-    # Note: This may prompt the user to allow keychain access
     TEMP_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEMP_DIR"' EXIT
     TEMP_KEY="$TEMP_DIR/key.pem"
     TEMP_CERT="$TEMP_DIR/cert.pem"
     TEMP_P12="$TEMP_DIR/cert.p12"
+    TEMP_CONFIG="$TEMP_DIR/openssl.cnf"
 
-    # Generate a private key
+    # Generate openssl config that marks the cert as critical for codeSigning EKU.
+    # Without the codeSigning EKU, `security find-identity -p codesigning` filters
+    # the cert out and codesign cannot use it.
+    cat > "$TEMP_CONFIG" <<EOF
+[req]
+distinguished_name = req_dn
+prompt = no
+x509_extensions = v3_ca
+
+[req_dn]
+CN = $CERT_NAME
+O = skhd Development
+C = US
+
+[v3_ca]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+EOF
+
     openssl genrsa -out "$TEMP_KEY" 2048 2>/dev/null
 
-    # Generate a self-signed certificate
     openssl req -new -x509 -key "$TEMP_KEY" -out "$TEMP_CERT" -days 3650 \
-        -subj "/CN=$CERT_NAME/O=skhd Development/C=US" 2>/dev/null
+        -config "$TEMP_CONFIG" 2>/dev/null
 
-    # Convert to PKCS12 format for import
-    openssl pkcs12 -export -out "$TEMP_P12" -inkey "$TEMP_KEY" -in "$TEMP_CERT" \
-        -passout pass: 2>/dev/null
+    # macOS `security import` rejects empty-password p12 files produced by
+    # OpenSSL 3+ ("MAC verification failed during PKCS12 import"). Use a
+    # throwaway password and pass it to both export and import. The cert
+    # itself isn't password-protected once in the keychain.
+    P12_PASS="skhd-cert-import"
 
-    # Import into login keychain
-    if security import "$TEMP_P12" -k ~/Library/Keychains/login.keychain-db -T /usr/bin/codesign -T /usr/bin/security 2>/dev/null; then
+    # OpenSSL 3+ uses a stronger PKCS12 MAC by default that older `security`
+    # tools can't read. -legacy falls back to the algorithm macOS understands.
+    openssl pkcs12 -export -legacy -out "$TEMP_P12" -inkey "$TEMP_KEY" -in "$TEMP_CERT" \
+        -passout "pass:$P12_PASS" 2>/dev/null
+
+    if security import "$TEMP_P12" -k ~/Library/Keychains/login.keychain-db -P "$P12_PASS" \
+        -T /usr/bin/codesign -T /usr/bin/security >/dev/null 2>&1; then
         echo -e "${GREEN}✓ Certificate created successfully${NC}"
-
-        # Set the certificate to always trust for code signing
-        # Note: This may require admin password
-        CERT_HASH=$(security find-certificate -c "$CERT_NAME" -Z ~/Library/Keychains/login.keychain-db | awk '/SHA-256/ {print $NF}')
-        if [ -n "$CERT_HASH" ]; then
-            security set-key-partition-list -S apple-tool:,apple: -k "" ~/Library/Keychains/login.keychain-db 2>/dev/null || true
-            echo -e "${GREEN}✓ Certificate trust settings updated${NC}"
-        fi
+        # Allow codesign to use the key without prompting on every invocation.
+        security set-key-partition-list -S apple-tool:,apple: -k "" \
+            ~/Library/Keychains/login.keychain-db >/dev/null 2>&1 || true
     else
         echo -e "${RED}Failed to import certificate programmatically.${NC}"
         echo ""
@@ -68,25 +98,29 @@ if ! security find-certificate -c "$CERT_NAME" ~/Library/Keychains/login.keychai
         echo "6. Click 'Create'"
         echo ""
         echo "After creating the certificate, run this script again."
-        rm -rf "$TEMP_DIR"
         exit 1
     fi
-
-    # Clean up temporary files
-    rm -rf "$TEMP_DIR"
     echo ""
 fi
 
-# Sign the binary
-echo "Signing binary: $BINARY_PATH"
-codesign -f -s "$CERT_NAME" -i "$BUNDLE_ID" "$BINARY_PATH"
+if [ -n "$APP_PATH" ]; then
+    # Sign inner-out: Mach-O first, then the bundle.
+    echo "Signing inner binary: $INNER_BINARY"
+    codesign -f -s "$CERT_NAME" -i "$BUNDLE_ID" "$INNER_BINARY"
+    echo "Signing bundle: $APP_PATH"
+    codesign -f -s "$CERT_NAME" -i "$BUNDLE_ID" "$APP_PATH"
+    VERIFY_TARGET="$APP_PATH"
+else
+    echo "Signing binary: $INNER_BINARY"
+    codesign -f -s "$CERT_NAME" -i "$BUNDLE_ID" "$INNER_BINARY"
+    VERIFY_TARGET="$INNER_BINARY"
+fi
 
-# Verify the signature
-if codesign -v "$BINARY_PATH" 2>/dev/null; then
-    echo -e "${GREEN}✓ Successfully signed $BINARY_PATH${NC}"
+if codesign -v "$VERIFY_TARGET" 2>/dev/null; then
+    echo -e "${GREEN}✓ Successfully signed $VERIFY_TARGET${NC}"
     echo ""
     echo "Signature details:"
-    codesign -dv "$BINARY_PATH" 2>&1 | grep -E "Authority|Identifier|Signature"
+    codesign -dv --verbose=2 "$VERIFY_TARGET" 2>&1 | grep -E "Authority|Identifier|Signature|Format"
 else
     echo -e "${RED}✗ Signature verification failed${NC}"
     exit 1
@@ -94,9 +128,18 @@ fi
 
 echo ""
 echo -e "${GREEN}Code signing complete!${NC}"
-echo "The binary is now signed with certificate '$CERT_NAME'"
-echo ""
-echo "Next steps:"
-echo "1. Run skhd: $BINARY_PATH"
-echo "2. Grant accessibility permissions in System Settings → Privacy & Security → Accessibility"
-echo "3. The permissions should persist across rebuilds now"
+if [ -n "$APP_PATH" ]; then
+    echo "The bundle is now signed with certificate '$CERT_NAME'"
+    echo ""
+    echo "Next steps:"
+    echo "1. Add $APP_PATH in System Settings → Privacy & Security → Accessibility"
+    echo "2. Toggle the entry on"
+    echo "3. Run: skhd --install-service && skhd --start-service"
+else
+    echo "The binary is now signed with certificate '$CERT_NAME'"
+    echo ""
+    echo "Next steps:"
+    echo "1. Run skhd: $INNER_BINARY"
+    echo "2. Grant accessibility permissions in System Settings → Privacy & Security → Accessibility"
+    echo "3. The permissions should persist across rebuilds now"
+fi

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Wrap the skhd binary into a minimal .app bundle so macOS Tahoe / Sequoia
+# accept it for accessibility permission grants. The bundle structure also
+# makes TCC entries bundle-ID-keyed (com.jackielii.skhd) instead of path-keyed,
+# so permissions persist across `brew upgrade`.
+set -e
+
+BINARY_PATH="${1:?usage: make-app.sh <binary> <app-path>}"
+APP_PATH="${2:?usage: make-app.sh <binary> <app-path>}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO_ROOT/assets/Info.plist.template"
+VERSION_FILE="$REPO_ROOT/VERSION"
+
+if [ ! -f "$BINARY_PATH" ]; then
+    echo "Error: binary not found at $BINARY_PATH" >&2
+    exit 1
+fi
+if [ ! -f "$TEMPLATE" ]; then
+    echo "Error: Info.plist template not found at $TEMPLATE" >&2
+    exit 1
+fi
+
+VERSION=$(tr -d '\n' < "$VERSION_FILE")
+
+# Build the bundle next to a temp path then move into place atomically so a
+# failed signing run does not leave a half-written bundle.
+TMP_APP="${APP_PATH}.tmp"
+rm -rf "$TMP_APP" "$APP_PATH"
+mkdir -p "$TMP_APP/Contents/MacOS"
+
+sed "s/__VERSION__/${VERSION}/g" "$TEMPLATE" > "$TMP_APP/Contents/Info.plist"
+cp "$BINARY_PATH" "$TMP_APP/Contents/MacOS/skhd"
+chmod 755 "$TMP_APP/Contents/MacOS/skhd"
+
+mv "$TMP_APP" "$APP_PATH"
+echo "Bundle created at $APP_PATH"

--- a/scripts/make-app.sh
+++ b/scripts/make-app.sh
@@ -20,18 +20,24 @@ if [ ! -f "$TEMPLATE" ]; then
     echo "Error: Info.plist template not found at $TEMPLATE" >&2
     exit 1
 fi
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "Error: VERSION file not found at $VERSION_FILE" >&2
+    exit 1
+fi
 
 VERSION=$(tr -d '\n' < "$VERSION_FILE")
 
-# Build the bundle next to a temp path then move into place atomically so a
-# failed signing run does not leave a half-written bundle.
+# Build the new bundle in a temp path, then swap it in only after every step
+# has succeeded. If any command above the swap fails, set -e aborts and the
+# previously-installed $APP_PATH is left intact.
 TMP_APP="${APP_PATH}.tmp"
-rm -rf "$TMP_APP" "$APP_PATH"
+rm -rf "$TMP_APP"
 mkdir -p "$TMP_APP/Contents/MacOS"
 
 sed "s/__VERSION__/${VERSION}/g" "$TEMPLATE" > "$TMP_APP/Contents/Info.plist"
 cp "$BINARY_PATH" "$TMP_APP/Contents/MacOS/skhd"
 chmod 755 "$TMP_APP/Contents/MacOS/skhd"
 
+rm -rf "$APP_PATH"
 mv "$TMP_APP" "$APP_PATH"
 echo "Bundle created at $APP_PATH"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -95,6 +95,30 @@ if git rev-parse "$TAG" >/dev/null 2>&1; then
     exit 1
 fi
 
+# Verify homebrew-tap is bundle-aware. The release.yml auto-bump rewrites
+# the formula's URL + sha256, but does NOT touch the install block. With
+# 0.0.18+ the tarball contains skhd.app/ instead of a bare binary, so a
+# pre-bundle install block (`bin.install "skhd-arm64-macos" => "skhd"`)
+# would silently produce broken installs after the auto-bump runs. Block
+# the release until the formula has the bundle-aware install logic.
+echo "Checking homebrew-tap formula is bundle-aware..."
+HEAD_FORMULA=$(curl -fsSL https://raw.githubusercontent.com/jackielii/homebrew-tap/main/Formula/skhd-zig.rb 2>/dev/null || true)
+if [ -z "$HEAD_FORMULA" ]; then
+    echo -e "${YELLOW}Warning: could not fetch homebrew-tap formula${NC}"
+    echo "Continue anyway? (y/n)"
+    read -r CONFIRM
+    if [ "$CONFIRM" != "y" ]; then
+        exit 1
+    fi
+elif ! echo "$HEAD_FORMULA" | grep -q 'File.directory?("skhd.app")'; then
+    echo -e "${RED}Error: homebrew-tap/main formula is NOT bundle-aware.${NC}"
+    echo "Releasing v$CURRENT_VERSION now will break 'brew install jackielii/tap/skhd-zig'"
+    echo "for everyone, because the auto-bump rewrites a stale install block."
+    echo ""
+    echo "Merge the bundle-aware formula PR first, then re-run this script."
+    exit 1
+fi
+
 echo -e "${GREEN}✓ Pre-flight checks passed${NC}"
 echo ""
 
@@ -147,11 +171,22 @@ if ! zig build test; then
 fi
 echo -e "${GREEN}✓ Tests passed${NC}"
 
-# Step 5: Build release binaries
+# Step 5: Build release artifacts (bare binary + .app bundle)
+# The release pipeline ships skhd.app inside skhd-<arch>-macos.tar.gz, so
+# verify the bundle layout builds cleanly here before tagging.
 echo ""
-echo -e "${BLUE}[Step 5/$TOTAL_STEPS] Building release binaries...${NC}"
+echo -e "${BLUE}[Step 5/$TOTAL_STEPS] Building release artifacts...${NC}"
 zig build -Doptimize=ReleaseFast
-echo -e "${GREEN}✓ Release binaries built${NC}"
+zig build app -Doptimize=ReleaseFast
+test -f zig-out/skhd.app/Contents/MacOS/skhd || {
+    echo -e "${RED}Error: skhd.app missing inner binary${NC}"
+    exit 1
+}
+test -f zig-out/skhd.app/Contents/Info.plist || {
+    echo -e "${RED}Error: skhd.app missing Info.plist${NC}"
+    exit 1
+}
+echo -e "${GREEN}✓ Release artifacts built (bare binary + skhd.app bundle)${NC}"
 
 # Step 6: Generate release notes using Claude
 echo ""
@@ -186,9 +221,10 @@ echo -e "${GREEN}✓ Tag pushed to origin${NC}"
 
 echo ""
 echo "GitHub Actions will now automatically:"
-echo "  - Build binaries for both architectures"
-echo "  - Create a GitHub release"
-echo "  - Update the Homebrew formula"
+echo "  - Build skhd.app bundles for both architectures (arm64 + x86_64)"
+echo "  - Code-sign with skhd-cert (if MACOS_CERTIFICATE secret is set)"
+echo "  - Create a GitHub release with skhd-<arch>-macos.tar.gz containing skhd.app"
+echo "  - Update the Homebrew formula (URL + sha256)"
 
 # Step 8: Bump version if requested
 if [ "$BUMP_VERSION" = true ]; then

--- a/src/EventTap.zig
+++ b/src/EventTap.zig
@@ -15,14 +15,30 @@ pub fn enabled(self: *EventTap) bool {
 // pub const CGEventTapCallBack = ?*const fn (CGEventTapProxy, CGEventType, CGEventRef, ?*anyopaque) callconv(.c) CGEventRef;
 
 pub fn begin(self: *EventTap, callback: c.CGEventTapCallBack, user_info: ?*anyopaque) !void {
-    self.handle = c.CGEventTapCreate(c.kCGSessionEventTap, c.kCGHeadInsertEventTap, //
-        c.kCGEventTapOptionDefault, self.mask, callback, user_info);
-    if (self.enabled()) {
-        self.runloop_source = c.CFMachPortCreateRunLoopSource(c.kCFAllocatorDefault, self.handle, 0);
-        c.CFRunLoopAddSource(c.CFRunLoopGetMain(), self.runloop_source, c.kCFRunLoopCommonModes);
-    } else {
-        return error.AccessibilityPermissionDenied;
+    // CGEventTapCreate can transiently return NULL during early login on macOS
+    // (Tahoe especially) when WindowServer/TCC haven't finished coming up, even
+    // though accessibility permissions are granted. Retry briefly before giving
+    // up; a real permissions denial will fail every attempt and surface the
+    // same error after the retry budget is spent.
+    const max_attempts: u8 = 10;
+    const retry_delay_ns: u64 = 500 * std.time.ns_per_ms;
+
+    var attempt: u8 = 0;
+    while (attempt < max_attempts) : (attempt += 1) {
+        self.handle = c.CGEventTapCreate(c.kCGSessionEventTap, c.kCGHeadInsertEventTap, //
+            c.kCGEventTapOptionDefault, self.mask, callback, user_info);
+        if (self.enabled()) {
+            self.runloop_source = c.CFMachPortCreateRunLoopSource(c.kCFAllocatorDefault, self.handle, 0);
+            c.CFRunLoopAddSource(c.CFRunLoopGetMain(), self.runloop_source, c.kCFRunLoopCommonModes);
+            if (attempt > 0) log.info("Event tap created on attempt {d}/{d}", .{ attempt + 1, max_attempts });
+            return;
+        }
+        if (attempt + 1 < max_attempts) {
+            log.warn("Event tap creation failed (attempt {d}/{d}), retrying in 500ms...", .{ attempt + 1, max_attempts });
+            std.time.sleep(retry_delay_ns);
+        }
     }
+    return error.AccessibilityPermissionDenied;
 }
 
 pub fn deinit(self: *EventTap) void {

--- a/src/service.zig
+++ b/src/service.zig
@@ -101,6 +101,25 @@ const plist_template =
     \\
 ;
 
+/// Pick a path to recommend in error messages for the System Settings →
+/// Accessibility picker. Tahoe's picker only accepts `.app` bundles, so we
+/// prefer `/Applications/skhd.app` when present, fall back to the `.app`
+/// inferred from a binary that lives inside a bundle, and finally return the
+/// caller's path unchanged for bare-binary installs.
+pub fn resolveBundlePath(allocator: std.mem.Allocator, exe_path: []const u8) ![]const u8 {
+    const apps_path = "/Applications/skhd.app";
+    if (std.fs.accessAbsolute(apps_path, .{})) |_| {
+        return allocator.dupe(u8, apps_path);
+    } else |_| {}
+
+    const marker = ".app/Contents/MacOS/";
+    if (std.mem.indexOf(u8, exe_path, marker)) |idx| {
+        return allocator.dupe(u8, exe_path[0 .. idx + 4]); // keep ".app"
+    }
+
+    return allocator.dupe(u8, exe_path);
+}
+
 /// Resolve a Homebrew Cellar path (e.g. /opt/homebrew/Cellar/skhd-zig/0.0.15/bin/skhd)
 /// to its stable opt symlink (/opt/homebrew/opt/skhd-zig/bin/skhd) so the plist
 /// keeps working across `brew upgrade` + `brew cleanup`. Returns the input
@@ -334,46 +353,128 @@ pub fn reloadConfig(allocator: std.mem.Allocator) !void {
     std.debug.print("Sent reload signal to skhd (PID {d})\n", .{pid});
 }
 
+/// State of the LaunchAgent as known to launchd, from `launchctl list`.
+const DaemonState = union(enum) {
+    /// Agent isn't loaded into launchd at all (nobody ran --start-service or
+    /// the plist isn't installed).
+    not_loaded,
+    /// Agent is loaded but currently not running — usually means it just
+    /// exited and launchd is waiting for `ThrottleInterval` before respawning.
+    loaded_idle,
+    /// Agent is loaded and the daemon process is alive.
+    running: i32,
+};
+
+fn getDaemonState(allocator: std.mem.Allocator) DaemonState {
+    const argv = [_][]const u8{ "launchctl", "list" };
+    var child = std.process.Child.init(&argv, allocator);
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Ignore;
+    child.spawn() catch return .not_loaded;
+
+    var stdout_data = std.ArrayList(u8).init(allocator);
+    defer stdout_data.deinit();
+    if (child.stdout) |stdout| {
+        stdout.reader().readAllArrayList(&stdout_data, 1 << 20) catch return .not_loaded;
+    }
+    _ = child.wait() catch return .not_loaded;
+
+    var lines = std.mem.splitScalar(u8, stdout_data.items, '\n');
+    while (lines.next()) |line| {
+        if (!std.mem.endsWith(u8, line, "\tcom.jackielii.skhd")) continue;
+        // Format: "<PID-or-->\t<exit>\t<label>"
+        var fields = std.mem.splitScalar(u8, line, '\t');
+        const pid_str = fields.next() orelse return .loaded_idle;
+        if (std.mem.eql(u8, pid_str, "-")) return .loaded_idle;
+        const pid = std.fmt.parseInt(i32, pid_str, 10) catch return .loaded_idle;
+        if (pid > 0) return .{ .running = pid };
+        return .loaded_idle;
+    }
+    return .not_loaded;
+}
+
+const EventTapHealth = enum { unknown, working, denied };
+
+/// Look at the tail of the daemon's log file to determine whether the most
+/// recent event-tap attempt succeeded. This is the only reliable way to
+/// answer "does the daemon actually have accessibility right now?" from the
+/// CLI: AXIsProcessTrusted() in a CLI process reports the *terminal's*
+/// trust state, not skhd's, because the CLI is the responsible process.
+fn getEventTapHealth(allocator: std.mem.Allocator) EventTapHealth {
+    const home = std.posix.getenv("HOME") orelse return .unknown;
+    const log_path = std.fmt.allocPrint(allocator, "{s}/Library/Logs/skhd.log", .{home}) catch return .unknown;
+    defer allocator.free(log_path);
+
+    const file = std.fs.openFileAbsolute(log_path, .{}) catch return .unknown;
+    defer file.close();
+
+    const stat = file.stat() catch return .unknown;
+    const tail_size: u64 = 8192;
+    if (stat.size == 0) return .unknown;
+    const start: u64 = if (stat.size > tail_size) stat.size - tail_size else 0;
+    file.seekTo(start) catch return .unknown;
+
+    const content = file.readToEndAlloc(allocator, tail_size) catch return .unknown;
+    defer allocator.free(content);
+
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    var last: EventTapHealth = .unknown;
+    while (lines.next()) |line| {
+        if (std.mem.indexOf(u8, line, "Event tap created successfully") != null or
+            std.mem.indexOf(u8, line, "Event tap created on attempt") != null)
+        {
+            last = .working;
+        } else if (std.mem.indexOf(u8, line, "ACCESSIBILITY PERMISSIONS REQUIRED") != null or
+            std.mem.indexOf(u8, line, "Event tap creation failed") != null)
+        {
+            last = .denied;
+        }
+    }
+    return last;
+}
+
 pub fn checkServiceStatus(allocator: std.mem.Allocator) !void {
-    // Check if service is installed
     const service_path = try getServicePath(allocator);
     defer allocator.free(service_path);
 
     const service_installed = blk: {
-        std.fs.accessAbsolute(service_path, .{}) catch {
-            break :blk false;
-        };
+        std.fs.accessAbsolute(service_path, .{}) catch break :blk false;
         break :blk true;
     };
 
-    // Check if skhd is running
-    const pid = try readPidFile(allocator);
-    const is_running = if (pid) |p| isProcessRunning(p) else false;
-
-    // Check accessibility permissions
-    const has_permissions = hasAccessibilityPermissions();
+    const daemon_state = getDaemonState(allocator);
+    const tap_health = getEventTapHealth(allocator);
 
     std.debug.print("skhd service status:\n", .{});
-    std.debug.print("  Service installed: {s}\n", .{if (service_installed) "Yes" else "No"});
-    std.debug.print("  Currently running: {s}", .{if (is_running) "Yes" else "No"});
-    if (is_running and pid != null) {
-        std.debug.print(" (PID {d})", .{pid.?});
+    std.debug.print("  Service installed:    {s}\n", .{if (service_installed) "Yes" else "No"});
+
+    switch (daemon_state) {
+        .running => |pid| std.debug.print("  Daemon running:       Yes (PID {d})\n", .{pid}),
+        .loaded_idle => std.debug.print("  Daemon running:       No (loaded, waiting for respawn — see log)\n", .{}),
+        .not_loaded => std.debug.print("  Daemon running:       No (LaunchAgent not loaded)\n", .{}),
     }
-    std.debug.print("\n", .{});
-    std.debug.print("  Accessibility permissions: {s}\n", .{if (has_permissions) "Granted" else "Not granted"});
+
+    const tap_label = switch (tap_health) {
+        .working => "Yes (event tap active)",
+        .denied => "No (accessibility denied — see remediation below)",
+        .unknown => "Unknown (no recent event-tap activity in log)",
+    };
+    std.debug.print("  Hotkeys functional:   {s}\n", .{tap_label});
 
     if (service_installed) {
-        std.debug.print("  Service path: {s}\n", .{service_path});
-        std.debug.print("  Log file: {s}/Library/Logs/skhd.log\n", .{std.posix.getenv("HOME") orelse "~"});
+        std.debug.print("  Service path:         {s}\n", .{service_path});
+        std.debug.print("  Log file:             {s}/Library/Logs/skhd.log\n", .{std.posix.getenv("HOME") orelse "~"});
     }
 
     if (!service_installed) {
         std.debug.print("\nTo install the service, run: skhd --install-service\n", .{});
-    } else if (!has_permissions) {
+    } else if (daemon_state == .not_loaded) {
+        std.debug.print("\nTo start the service, run: skhd --start-service\n", .{});
+    } else if (tap_health == .denied) {
         std.debug.print("\nTo grant accessibility permissions:\n", .{});
         std.debug.print("1. Open System Settings → Privacy & Security → Accessibility\n", .{});
-        std.debug.print("2. Add skhd and enable it\n", .{});
-    } else if (!is_running) {
-        std.debug.print("\nTo start the service, run: skhd --start-service\n", .{});
+        std.debug.print("2. Add /Applications/skhd.app and enable it\n", .{});
+        std.debug.print("3. Run: skhd --restart-service\n", .{});
+        std.debug.print("\nIf the picker won't accept the .app, see docs/CODE_SIGNING.md.\n", .{});
     }
 }

--- a/src/service.zig
+++ b/src/service.zig
@@ -3,8 +3,9 @@ const builtin = @import("builtin");
 const c = @import("c.zig");
 const log = std.log.scoped(.service);
 
-// Import C function
+// Import C functions
 extern "c" fn getpid() c_int;
+extern "c" fn getuid() c_uint;
 
 /// Check if the current process has accessibility permissions
 pub fn hasAccessibilityPermissions() bool {
@@ -223,7 +224,27 @@ pub fn startService(allocator: std.mem.Allocator) !void {
     const service_path = try getServicePath(allocator);
     defer allocator.free(service_path);
 
-    const argv = [_][]const u8{ "launchctl", "load", "-w", service_path };
+    const uid = getuid();
+    const target = try std.fmt.allocPrint(allocator, "gui/{d}/com.jackielii.skhd", .{uid});
+    defer allocator.free(target);
+    const domain = try std.fmt.allocPrint(allocator, "gui/{d}", .{uid});
+    defer allocator.free(domain);
+
+    // Clear any persistent disable flag. Older versions of skhd used
+    // `launchctl unload -w` for --stop-service, which writes a flag to the
+    // disable list that survives reboot — so on the next login launchd
+    // refuses to auto-load the agent even with RunAtLoad=true. `enable` is
+    // idempotent and a no-op when the agent isn't disabled.
+    {
+        const enable_argv = [_][]const u8{ "launchctl", "enable", target };
+        var enable_child = std.process.Child.init(&enable_argv, allocator);
+        enable_child.stdout_behavior = .Ignore;
+        enable_child.stderr_behavior = .Ignore;
+        enable_child.spawn() catch {};
+        _ = enable_child.wait() catch {};
+    }
+
+    const argv = [_][]const u8{ "launchctl", "bootstrap", domain, service_path };
     var child = std.process.Child.init(&argv, allocator);
     child.stdout_behavior = .Ignore;
     child.stderr_behavior = .Pipe;
@@ -241,12 +262,19 @@ pub fn startService(allocator: std.mem.Allocator) !void {
     const term = try child.wait();
 
     if (term != .Exited or term.Exited != 0) {
-        if (stderr_data.items.len > 0) {
-            std.debug.print("Failed to start service: {s}\n", .{stderr_data.items});
-        } else {
-            std.debug.print("Failed to start service. Check ~/Library/Logs/skhd.log for details.\n", .{});
+        // bootstrap returns errno 17 (EEXIST, "File exists") or 37
+        // ("Operation already in progress") when the agent is already
+        // loaded. Both are no-ops for --start-service.
+        const already_loaded = std.mem.indexOf(u8, stderr_data.items, "File exists") != null or
+            std.mem.indexOf(u8, stderr_data.items, "already in progress") != null;
+        if (!already_loaded) {
+            if (stderr_data.items.len > 0) {
+                std.debug.print("Failed to start service: {s}\n", .{stderr_data.items});
+            } else {
+                std.debug.print("Failed to start service. Check ~/Library/Logs/skhd.log for details.\n", .{});
+            }
+            return error.ServiceStartFailed;
         }
-        return error.ServiceStartFailed;
     }
 
     std.debug.print("Service started successfully.\n", .{});
@@ -254,10 +282,13 @@ pub fn startService(allocator: std.mem.Allocator) !void {
 }
 
 pub fn stopService(allocator: std.mem.Allocator) !void {
-    const service_path = try getServicePath(allocator);
-    defer allocator.free(service_path);
+    const uid = getuid();
+    const target = try std.fmt.allocPrint(allocator, "gui/{d}/com.jackielii.skhd", .{uid});
+    defer allocator.free(target);
 
-    const argv = [_][]const u8{ "launchctl", "unload", "-w", service_path };
+    // bootout unloads the agent without touching the disable list, so the
+    // agent can still auto-load on next login (unlike legacy `unload -w`).
+    const argv = [_][]const u8{ "launchctl", "bootout", target };
     var child = std.process.Child.init(&argv, allocator);
     child.stdout_behavior = .Ignore;
     child.stderr_behavior = .Ignore;

--- a/src/service.zig
+++ b/src/service.zig
@@ -88,17 +88,51 @@ const plist_template =
     \\    <key>KeepAlive</key>
     \\    <true/>
     \\    <key>StandardOutPath</key>
-    \\    <string>/tmp/skhd_{s}.log</string>
+    \\    <string>{s}/Library/Logs/skhd.log</string>
     \\    <key>StandardErrorPath</key>
-    \\    <string>/tmp/skhd_{s}.log</string>
+    \\    <string>{s}/Library/Logs/skhd.log</string>
     \\    <key>ThrottleInterval</key>
-    \\    <integer>30</integer>
+    \\    <integer>10</integer>
     \\    <key>ProcessType</key>
     \\    <string>Interactive</string>
     \\</dict>
     \\</plist>
     \\
 ;
+
+/// Resolve a Homebrew Cellar path (e.g. /opt/homebrew/Cellar/skhd-zig/0.0.15/bin/skhd)
+/// to its stable opt symlink (/opt/homebrew/opt/skhd-zig/bin/skhd) so the plist
+/// keeps working across `brew upgrade` + `brew cleanup`. Returns the input
+/// unchanged when no stable equivalent exists.
+pub fn resolveStableExePath(allocator: std.mem.Allocator, exe_path: []const u8) ![]const u8 {
+    const cellar_marker = "/Cellar/";
+    const idx = std.mem.indexOf(u8, exe_path, cellar_marker) orelse {
+        return allocator.dupe(u8, exe_path);
+    };
+
+    const prefix = exe_path[0..idx];
+    const after_cellar = exe_path[idx + cellar_marker.len ..];
+
+    const formula_end = std.mem.indexOfScalar(u8, after_cellar, '/') orelse {
+        return allocator.dupe(u8, exe_path);
+    };
+    const formula = after_cellar[0..formula_end];
+
+    const after_formula = after_cellar[formula_end + 1 ..];
+    const version_end = std.mem.indexOfScalar(u8, after_formula, '/') orelse {
+        return allocator.dupe(u8, exe_path);
+    };
+    const rest = after_formula[version_end + 1 ..];
+
+    const candidate = try std.fmt.allocPrint(allocator, "{s}/opt/{s}/{s}", .{ prefix, formula, rest });
+    errdefer allocator.free(candidate);
+
+    std.fs.accessAbsolute(candidate, .{}) catch {
+        allocator.free(candidate);
+        return allocator.dupe(u8, exe_path);
+    };
+    return candidate;
+}
 
 pub fn getServicePath(allocator: std.mem.Allocator) ![]const u8 {
     const home = std.posix.getenv("HOME") orelse return error.NoHomeDirectory;
@@ -110,31 +144,40 @@ fn installOrUpdateService(allocator: std.mem.Allocator) !void {
     const service_path = try getServicePath(allocator);
     defer allocator.free(service_path);
 
-    // Get the current executable path
-    const exe_path = try std.fs.selfExePathAlloc(allocator);
+    // Get the current executable path, then prefer a Homebrew-stable symlink
+    // when available so the plist survives `brew upgrade` + `brew cleanup`.
+    const raw_exe_path = try std.fs.selfExePathAlloc(allocator);
+    defer allocator.free(raw_exe_path);
+    const exe_path = try resolveStableExePath(allocator, raw_exe_path);
     defer allocator.free(exe_path);
 
     // Get PATH environment variable
     const path_env = std.posix.getenv("PATH") orelse "/usr/local/bin:/usr/bin:/bin";
 
-    // Get username for log file
-    const username = std.posix.getenv("USER") orelse "unknown";
+    const home = std.posix.getenv("HOME") orelse return error.NoHomeDirectory;
 
     // Format the plist content
     const plist_content = try std.fmt.allocPrint(allocator, plist_template, .{
         exe_path,
         path_env,
-        username,
-        username,
+        home,
+        home,
     });
     defer allocator.free(plist_content);
 
     // Create LaunchAgents directory if it doesn't exist
-    const home = std.posix.getenv("HOME") orelse return error.NoHomeDirectory;
     const launch_agents_dir = try std.fmt.allocPrint(allocator, "{s}/Library/LaunchAgents", .{home});
     defer allocator.free(launch_agents_dir);
 
     std.fs.makeDirAbsolute(launch_agents_dir) catch |err| {
+        if (err != error.PathAlreadyExists) return err;
+    };
+
+    // Ensure ~/Library/Logs exists so launchd can write Standard{Out,Error}Path
+    const logs_dir = try std.fmt.allocPrint(allocator, "{s}/Library/Logs", .{home});
+    defer allocator.free(logs_dir);
+
+    std.fs.makeDirAbsolute(logs_dir) catch |err| {
         if (err != error.PathAlreadyExists) return err;
     };
 
@@ -201,13 +244,13 @@ pub fn startService(allocator: std.mem.Allocator) !void {
         if (stderr_data.items.len > 0) {
             std.debug.print("Failed to start service: {s}\n", .{stderr_data.items});
         } else {
-            std.debug.print("Failed to start service. Check /tmp/skhd_$USER.log for details.\n", .{});
+            std.debug.print("Failed to start service. Check ~/Library/Logs/skhd.log for details.\n", .{});
         }
         return error.ServiceStartFailed;
     }
 
     std.debug.print("Service started successfully.\n", .{});
-    std.debug.print("Check logs at: /tmp/skhd_{s}.log\n", .{std.posix.getenv("USER") orelse "unknown"});
+    std.debug.print("Check logs at: {s}/Library/Logs/skhd.log\n", .{std.posix.getenv("HOME") orelse "~"});
 }
 
 pub fn stopService(allocator: std.mem.Allocator) !void {
@@ -290,7 +333,7 @@ pub fn checkServiceStatus(allocator: std.mem.Allocator) !void {
 
     if (service_installed) {
         std.debug.print("  Service path: {s}\n", .{service_path});
-        std.debug.print("  Log file: /tmp/skhd_{s}.log\n", .{std.posix.getenv("USER") orelse "unknown"});
+        std.debug.print("  Log file: {s}/Library/Logs/skhd.log\n", .{std.posix.getenv("HOME") orelse "~"});
     }
 
     if (!service_installed) {

--- a/src/skhd.zig
+++ b/src/skhd.zig
@@ -12,6 +12,7 @@ const ModifierFlag = Keycodes.ModifierFlag;
 const Mappings = @import("Mappings.zig");
 const Mode = @import("Mode.zig");
 const Parser = @import("Parser.zig");
+const service = @import("service.zig");
 const Tracer = @import("Tracer.zig");
 
 // Use scoped logging for skhd module
@@ -157,9 +158,14 @@ pub fn run(self: *Skhd, enable_hotload: bool) !void {
     log.info("Starting event tap", .{});
     self.event_tap.begin(keyHandler, self) catch |err| {
         if (err == error.AccessibilityPermissionDenied) {
-            const allocated_path: ?[]u8 = std.fs.selfExePathAlloc(self.allocator) catch null;
-            defer if (allocated_path) |path| self.allocator.free(path);
-            const exe_path = allocated_path orelse "/opt/homebrew/bin/skhd";
+            const raw_path: ?[]u8 = std.fs.selfExePathAlloc(self.allocator) catch null;
+            defer if (raw_path) |p| self.allocator.free(p);
+            const stable_path: ?[]const u8 = if (raw_path) |p|
+                service.resolveStableExePath(self.allocator, p) catch null
+            else
+                null;
+            defer if (stable_path) |p| self.allocator.free(p);
+            const exe_path = stable_path orelse raw_path orelse "/opt/homebrew/bin/skhd";
 
             log.err(
                 \\

--- a/src/skhd.zig
+++ b/src/skhd.zig
@@ -165,31 +165,35 @@ pub fn run(self: *Skhd, enable_hotload: bool) !void {
             else
                 null;
             defer if (stable_path) |p| self.allocator.free(p);
-            const exe_path = stable_path orelse raw_path orelse "/opt/homebrew/bin/skhd";
+            const bundle_path: ?[]const u8 = if (stable_path) |p|
+                service.resolveBundlePath(self.allocator, p) catch null
+            else
+                null;
+            defer if (bundle_path) |p| self.allocator.free(p);
+            const display_path = bundle_path orelse stable_path orelse raw_path orelse "/Applications/skhd.app";
 
             log.err(
                 \\
                 \\=====================================================
                 \\ACCESSIBILITY PERMISSIONS REQUIRED
                 \\=====================================================
-                \\skhd requires accessibility permissions to function.
+                \\skhd needs accessibility permissions to capture hotkeys.
                 \\
-                \\Please grant accessibility permissions:
                 \\1. Open System Settings → Privacy & Security → Accessibility
-                \\2. Click the lock to make changes
-                \\3. Add this binary: {s}
-                \\4. Make sure it's enabled (checkbox checked)
-                \\5. Restart skhd
+                \\2. Click '+' and add: {s}
+                \\3. Toggle the entry on
+                \\4. Run: skhd --restart-service
                 \\
                 \\Troubleshooting:
-                \\If skhd is already listed but still not working:
-                \\- Remove the existing skhd entry
-                \\- Stop the service: skhd --stop-service
-                \\- Re-add skhd to the list - Or just restart the service to see the entry added
-                \\- Enable the entry and run skhd --restart-service
+                \\- macOS Tahoe's picker only accepts .app bundles. If the path
+                \\  above is not a .app, install the app bundle (e.g.
+                \\  `brew upgrade skhd-zig`) and re-run --install-service.
+                \\- If skhd was working before and stopped after a binary swap,
+                \\  a stale TCC entry may need clearing. See:
+                \\    docs/CODE_SIGNING.md (Troubleshooting section)
                 \\=====================================================
                 \\
-            , .{exe_path});
+            , .{display_path});
         }
         return err;
     };


### PR DESCRIPTION
## Why

macOS 26 (Tahoe) shipped with several behavior changes that broke skhd installs in subtle ways:

1. **Boot-time race** — `CGEventTapCreate` returns NULL during early login while WindowServer/TCC are still coming up. The daemon would exit and wait the full `ThrottleInterval` before launchd respawned it, sometimes never within the user's expectation window after reboot.
2. **`launchctl unload -w` persisted disable across reboots** — calling `--stop-service` once silently prevented the agent from auto-loading on subsequent boots.
3. **Path-keyed TCC entries broke on every binary swap** — TCC tied accessibility grants to the on-disk code requirement of a specific binary path. Every `brew upgrade` (different Cellar version path) and every rebuild (different signature) silently invalidated the entry.
4. **Tahoe Accessibility picker silently rejects bare Mach-O binaries** — only `.app` bundles get accepted via the `+` button. Path-keyed entries that already exist in TCC are hidden from the UI.
5. **Logs to `/tmp/skhd_$USER.log`** — wiped at every boot, so post-reboot failures were undiagnosable.

## What changed

| Commit | Layer |
|---|---|
| `bf25f43` | Plist now points at the stable `/opt/homebrew/opt/skhd-zig/...` symlink (survives `brew upgrade`); event-tap creation retries 10× over 5 s for the boot-time race; logs move to `~/Library/Logs/skhd.log`; `ThrottleInterval` 30 → 10 s |
| `f5e60ae` | `launchctl bootstrap` / `bootout` instead of legacy `load -w` / `unload -w`; `--start-service` clears stale disable flags on upgrade |
| `bb54b93` | Ship `skhd.app` bundle (TCC entries become bundle-ID-keyed, picker accepts the path); `zig build app` and `zig build sign-app` steps; `scripts/codesign.sh` fixes for empty-p12-password import + missing `codeSigning` EKU on Tahoe + OpenSSL 3.6; release.yml ships `.app` under existing tarball name |
| `5e5d8dd` | `--status` reads `launchctl list` and the log tail (truthful daemon health) instead of `AXIsProcessTrusted()` of the CLI process (misleading — reports terminal's trust); error message points at the bundle path the picker will accept |
| `979201d` | README install/log/service references aligned |

## User-facing impact

End users on `brew upgrade`:

- One-time re-grant of Accessibility for `/Applications/skhd.app` (because the TCC entry transitions from path-keyed to bundle-ID-keyed)
- After that grant, **all future upgrades and rebuilds keep working without re-granting** — that's the long-term payoff of the bundle wrapper

`docs/UPGRADING.md` walks them through the legacy disable-flag clear, stale-TCC purge, and one-time grant.

## Test plan

Validated end-to-end on macOS 26.2 (Tahoe) ARM64:

- [x] `zig build test` green (all module + tests.zig suites)
- [x] `zig build` and `zig build app` produce expected artifacts
- [x] `zig build sign-app` produces signed bundle: `Format=app bundle with Mach-O thin (arm64)`, `Authority=skhd-cert`, `Identifier=com.jackielii.skhd`, `Sealed Resources version=2`
- [x] Bundle installed at `/Applications/skhd.app`, granted via Accessibility picker on Tahoe (entry persists in TCC as `client_type=0`, `auth_value=2`)
- [x] LaunchAgent loads at login, `--status` reports `Daemon running: Yes` + `Hotkeys functional: Yes (event tap active)`
- [x] Live hotkey firing confirmed (yabai space-switch bindings observed in `~/Library/Logs/skhd.log`)
- [x] Retry loop exercised — log shows `Event tap creation failed (attempt 1/10)... Event tap created on attempt 2/10`, daemon recovered
- [x] `--stop-service` followed by reboot no longer leaves agent in `disabled` state (verified via `launchctl print-disabled gui/$(id -u)`)
- [x] In-place binary replacement (`cp` over `/opt/homebrew/Cellar/.../bin/skhd` then re-sign) keeps daemon working — TCC bundle-ID entry survives the swap
- [x] CI workflow steps mirrored locally for all four optimize modes (Debug / ReleaseSafe / ReleaseFast / ReleaseSmall) — all exit 0

## Companion PR

Formula update to install the `.app` bundle and write logs to `~/Library/Logs`: [jackielii/homebrew-tap#feat/tahoe-app-bundle](https://github.com/jackielii/homebrew-tap/tree/feat/tahoe-app-bundle).

**Recommended merge order:**
1. Merge the homebrew-tap PR first — formula auto-detects payload shape, so it keeps working for current 0.0.17 users until 0.0.18 ships
2. Merge this PR
3. Tag `v0.0.18` — release.yml ships the `.app` tarball, auto-bump updates the formula's URL + SHA256, install block automatically takes the bundle code path