### PR TITLE
Mouse button bindings + synthesis (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The service will:
 ### Additional Features (New in skhd.zig!)
 
 - **Aliases**: Name a modifier combo or a single key (`.alias $hyper cmd + alt + ctrl + shift`, `.alias $grave 0x32`)
+- **Mouse buttons**: Bind on `mouse1`–`mouse5` (e.g. `cmd - mouse1 : ...`); use `->` for passthrough so the click still reaches the app
 - **Process groups**: Define named groups of applications for cleaner configs
 - **Command definitions**: Define reusable commands with placeholders to reduce repetition
 - **Key Forwarding**: Forward / remap key binding to another key binding

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -164,12 +164,20 @@ meh - mouse3 : open -a "Mission Control"
 mouse4 -> : echo "back button"   # passthrough: still goes to the app
 ```
 
+Mouse buttons can also be the **target** of a forward, so you can
+synthesize a click from a key (e.g. inside a layer):
+
+```bash
+fn_layer < enter | mouse1        # in fn_layer, enter = left-click
+fn_layer < space | cmd - mouse1  # cmd-click via the layer
+```
+
 ⚠️ Binding `mouse1` (or any mouse button) **without** a modifier and
 **without** `->` consumes every click in non-blacklisted apps and
 effectively breaks the trackpad. Pair with a modifier (`cmd - mouse1`)
-or use passthrough (`mouse1 -> : ...`) unless you really mean it. Mouse
-synthesis as a forward target (`cmd - x | mouse1`) and mouse-up / drag
-events are not supported.
+or use passthrough (`mouse1 -> : ...`) unless you really mean it.
+Mouse-up and drag events are not captured (skhd only sees the down
+edge); scroll-wheel events aren't bindable either.
 
 ## Configuration Directives
 

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -149,6 +149,28 @@ command   = command is executed through '$SHELL -c'
 - `play`, `previous`, `next` - Media playback
 - `rewind`, `fast` - Media navigation
 
+### Mouse Buttons (New in skhd.zig!)
+- `mouse1` - Left button
+- `mouse2` - Right button
+- `mouse3` - Middle button
+- `mouse4` - Back / fourth button
+- `mouse5` - Forward / fifth button
+
+Used the same way as keys — combine with modifiers via `-`, or stand alone:
+
+```bash
+cmd - mouse1 : echo "cmd-click"
+meh - mouse3 : open -a "Mission Control"
+mouse4 -> : echo "back button"   # passthrough: still goes to the app
+```
+
+⚠️ Binding `mouse1` (or any mouse button) **without** a modifier and
+**without** `->` consumes every click in non-blacklisted apps and
+effectively breaks the trackpad. Pair with a modifier (`cmd - mouse1`)
+or use passthrough (`mouse1 -> : ...`) unless you really mean it. Mouse
+synthesis as a forward target (`cmd - x | mouse1`) and mouse-up / drag
+events are not supported.
+
 ## Configuration Directives
 
 Configuration directives follow this syntax:

--- a/src/Keycodes.zig
+++ b/src/Keycodes.zig
@@ -127,7 +127,7 @@ pub const literal_keycode_str = [_][]const u8{
     // zig fmt: off
 
     // Fn mod
-    "delete",          "home",            "end", 
+    "delete",          "home",            "end",
     "pageup",          "pagedown",        "insert",
     "left",            "right",           "up",
     "down",            "f1",              "f2",
@@ -143,11 +143,29 @@ pub const literal_keycode_str = [_][]const u8{
     "play",            "previous",        "next",
     "rewind",          "fast",            "brightness_up",
     "brightness_down", "illumination_up", "illumination_down",
+
+    // Mouse buttons (no implicit modifier; synthetic keycodes above the
+    // u8 keyboard range so they can't collide with real kVK_ values)
+    "mouse1",          "mouse2",          "mouse3",
+    "mouse4",          "mouse5",
     // zig fmt: on
 };
 
 pub const KEY_HAS_IMPLICIT_FN_MOD = 4;
 pub const KEY_HAS_IMPLICIT_NX_MOD = 35;
+pub const KEY_FIRST_MOUSE = 48;
+
+/// Synthetic keycode base for mouse buttons. Keyboard kVK_* values
+/// fit in u8, so anything ≥ 0x10000 is unambiguously a mouse button.
+pub const MOUSE_BUTTON_BASE: u32 = 0x10000;
+
+pub inline fn mouseButtonCode(n: u8) u32 {
+    return MOUSE_BUTTON_BASE | @as(u32, n);
+}
+
+pub inline fn isMouseButton(keycode: u32) bool {
+    return keycode >= MOUSE_BUTTON_BASE;
+}
 
 pub const literal_keycode_value = [_]u32{
     c.kVK_Return,                 c.kVK_Tab,                  c.kVK_Space,
@@ -172,6 +190,10 @@ pub const literal_keycode_value = [_]u32{
     c.NX_KEYTYPE_PLAY,            c.NX_KEYTYPE_PREVIOUS,        c.NX_KEYTYPE_NEXT,
     c.NX_KEYTYPE_REWIND,          c.NX_KEYTYPE_FAST,            c.NX_KEYTYPE_BRIGHTNESS_UP,
     c.NX_KEYTYPE_BRIGHTNESS_DOWN, c.NX_KEYTYPE_ILLUMINATION_UP, c.NX_KEYTYPE_ILLUMINATION_DOWN,
+
+    // Mouse buttons
+    mouseButtonCode(1), mouseButtonCode(2), mouseButtonCode(3),
+    mouseButtonCode(4), mouseButtonCode(5),
     // zig fmt: on
 };
 
@@ -281,6 +303,26 @@ test "init_keycode_map" {
     // Verify literal keycodes exist in the arrays
     try std.testing.expect(literal_keycode_str.len > 0);
     try std.testing.expect(literal_keycode_value.len == literal_keycode_str.len);
+}
+
+test "mouse button literals are present and have synthetic codes" {
+    // mouse1..mouse5 must live at indices [KEY_FIRST_MOUSE, +5).
+    try std.testing.expectEqual(@as(usize, 5), literal_keycode_str.len - KEY_FIRST_MOUSE);
+    try std.testing.expectEqualStrings("mouse1", literal_keycode_str[KEY_FIRST_MOUSE]);
+    try std.testing.expectEqualStrings("mouse5", literal_keycode_str[KEY_FIRST_MOUSE + 4]);
+
+    // Synthetic codes are above the keyboard u8 range so they can never
+    // collide with a real kVK_* value.
+    for (literal_keycode_value[KEY_FIRST_MOUSE..]) |code| {
+        try std.testing.expect(isMouseButton(code));
+        try std.testing.expect(code > 0xFF);
+    }
+    try std.testing.expectEqual(mouseButtonCode(1), literal_keycode_value[KEY_FIRST_MOUSE]);
+    try std.testing.expectEqual(mouseButtonCode(5), literal_keycode_value[KEY_FIRST_MOUSE + 4]);
+
+    // Real keyboard keycodes must NOT register as mouse buttons.
+    try std.testing.expect(!isMouseButton(0x00)); // 'a'
+    try std.testing.expect(!isMouseButton(0x35)); // escape
 }
 
 test "duplicate keycode mapping returns error" {

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -601,10 +601,11 @@ fn parse_key_literal(self: *Parser) !Hotkey.KeyPress {
             if (i > Keycodes.KEY_HAS_IMPLICIT_FN_MOD and i < Keycodes.KEY_HAS_IMPLICIT_NX_MOD) {
                 // flags |= @intFromEnum(consts.hotkey_flag.Hotkey_Flag_Fn);
                 flags = flags.merge(.{ .@"fn" = true });
-            } else if (i >= Keycodes.KEY_HAS_IMPLICIT_NX_MOD) {
+            } else if (i >= Keycodes.KEY_HAS_IMPLICIT_NX_MOD and i < Keycodes.KEY_FIRST_MOUSE) {
                 // flags |= @intFromEnum(consts.hotkey_flag.Hotkey_Flag_NX);
                 flags = flags.merge(.{ .nx = true });
             }
+            // Mouse buttons (i >= KEY_FIRST_MOUSE) carry no implicit modifier.
             keycode = literal_keycode_value[i];
             break;
         }
@@ -2811,4 +2812,40 @@ test "alias - key alias inherits kind from referenced alias" {
     var it = default.hotkey_map.iterator();
     const hk = it.next().?.key_ptr.*;
     try std.testing.expectEqual(@as(u32, 0x32), hk.key);
+}
+
+test "mouse button - parses as a literal with synthetic keycode" {
+    const alloc = std.testing.allocator;
+    var parser = try Parser.init(alloc);
+    defer parser.deinit();
+    var mappings = try Mappings.init(alloc);
+    defer mappings.deinit();
+
+    try parser.parse(&mappings,
+        \\cmd - mouse1 : echo m1
+        \\mouse3 -> : echo m3
+    );
+
+    const default = mappings.mode_map.get("default").?;
+    try std.testing.expectEqual(@as(usize, 2), default.hotkey_map.count());
+
+    var saw_m1 = false;
+    var saw_m3 = false;
+    var it = default.hotkey_map.iterator();
+    while (it.next()) |entry| {
+        const hk = entry.key_ptr.*;
+        if (hk.key == Keycodes.mouseButtonCode(1)) {
+            saw_m1 = true;
+            try std.testing.expect(hk.flags.cmd);
+            // Mouse buttons must NOT pick up the implicit nx flag.
+            try std.testing.expect(!hk.flags.nx);
+            try std.testing.expect(!hk.flags.@"fn");
+        } else if (hk.key == Keycodes.mouseButtonCode(3)) {
+            saw_m3 = true;
+            try std.testing.expect(hk.flags.passthrough);
+            try std.testing.expect(!hk.flags.nx);
+        }
+    }
+    try std.testing.expect(saw_m1);
+    try std.testing.expect(saw_m3);
 }

--- a/src/skhd.zig
+++ b/src/skhd.zig
@@ -133,8 +133,15 @@ pub fn init(gpa: std.mem.Allocator, config_file: []const u8, verbose: bool, prof
     }
     errdefer if (hidutil) |h| h.deinit();
 
-    // Create event tap with keyboard and system defined events
-    const mask: u32 = (1 << c.kCGEventKeyDown) | (1 << c.NX_SYSDEFINED);
+    // Create event tap with keyboard, system-defined, and mouse-down events.
+    // Mouse-down is opt-in only via `mouse1`–`mouse5` bindings, but the tap
+    // mask is set unconditionally — `processHotkey` returns `.not_found` for
+    // un-bound mouse events and we pass them through, so an unused mask bit
+    // costs only a couple of dispatches per click.
+    const mask: u32 = (1 << c.kCGEventKeyDown) | (1 << c.NX_SYSDEFINED) //
+    | (1 << c.kCGEventLeftMouseDown) //
+    | (1 << c.kCGEventRightMouseDown) //
+    | (1 << c.kCGEventOtherMouseDown);
 
     return Skhd{
         .allocator = gpa,
@@ -653,6 +660,26 @@ fn keyHandler(proxy: c.CGEventTapProxy, typ: c.CGEventType, event: c.CGEventRef,
                 return event;
             };
         },
+        c.kCGEventLeftMouseDown => return self.handleMouseDown(event, 1) catch |err| {
+            log.err("Error handling mouse down: {}", .{err});
+            return event;
+        },
+        c.kCGEventRightMouseDown => return self.handleMouseDown(event, 2) catch |err| {
+            log.err("Error handling mouse down: {}", .{err});
+            return event;
+        },
+        c.kCGEventOtherMouseDown => {
+            // CGMouseEventButtonNumber is 0-based: 0=left, 1=right, 2=middle,
+            // 3=back, 4=forward. Left/right come through their own event
+            // types, so here we expect button >= 2 → mouse3..mouse5+.
+            const btn_raw = c.CGEventGetIntegerValueField(event, c.kCGMouseEventButtonNumber);
+            if (btn_raw < 2 or btn_raw > 4) return event;
+            const mouse_n: u8 = @intCast(btn_raw + 1);
+            return self.handleMouseDown(event, mouse_n) catch |err| {
+                log.err("Error handling mouse down: {}", .{err});
+                return event;
+            };
+        },
         else => return event,
     }
 }
@@ -680,6 +707,24 @@ inline fn handleKeyDown(self: *Skhd, event: c.CGEventRef) !c.CGEventRef {
     }
 
     const eventkey = createEventKey(event);
+    const result = try self.processHotkey(&eventkey, event, process_name);
+    return try self.handleHotkeyResult(result, event, eventkey, process_name);
+}
+
+inline fn handleMouseDown(self: *Skhd, event: c.CGEventRef, mouse_n: u8) !c.CGEventRef {
+    if (self.current_mode == null) return event;
+
+    // Skip self-generated events.
+    const marker = c.CGEventGetIntegerValueField(event, c.kCGEventSourceUserData);
+    if (marker == SKHD_EVENT_MARKER) return event;
+
+    const process_name = self.carbon_event.getProcessName();
+    if (self.mappings.blacklist.contains(process_name)) return event;
+
+    const eventkey = Hotkey.KeyPress{
+        .key = Keycodes.mouseButtonCode(mouse_n),
+        .flags = cgeventFlagsToHotkeyFlags(c.CGEventGetFlags(event)),
+    };
     const result = try self.processHotkey(&eventkey, event, process_name);
     return try self.handleHotkeyResult(result, event, eventkey, process_name);
 }

--- a/src/skhd.zig
+++ b/src/skhd.zig
@@ -1254,7 +1254,7 @@ fn handleSigint(_: c_int) callconv(.C) void {
 
 /// Reload configuration from file
 pub fn reloadConfig(self: *Skhd) !void {
-    log.info("Reloading configuration from: {s}", .{self.config_file});
+    log.warn("Reloading configuration from: {s}", .{self.config_file});
 
     // Parse new configuration
     var new_mappings = try Mappings.init(self.allocator);
@@ -1318,28 +1318,34 @@ pub fn reloadConfig(self: *Skhd) !void {
     // can dial fresh with the updated rules. Do this even when the
     // new config has no caps-class rules — closing the old socket
     // is how the grabber learns we don't want our previous rules
-    // applied any more (D5 will make this a hard "drop on close",
-    // for now this matches what grabber does when no apply_rules
-    // arrive).
+    // applied any more.
+    //
+    // No `bye` here: once apply_rules has succeeded, the grabber moves
+    // this socket out of `Ipc.serve` and into its subscriptionCallback,
+    // which only PEEKs for EOS and discards any frame the agent writes
+    // as "stray bytes". A bye on a subscription connection therefore
+    // never gets a reply — and worse, an `expectOk` read after it can
+    // pick up a queued `mode_change` push (logged as "unexpected type:
+    // mode_change") or block indefinitely. EOS-on-close is the only
+    // teardown signal the subscription path actually honors.
     if (self.layer_listener) |ll| {
         ll.deinit();
         self.layer_listener = null;
     }
     if (self.grabber_client) |gc| {
-        gc.bye() catch {};
         gc.close();
         self.allocator.destroy(gc);
         self.grabber_client = null;
     }
     self.forwardTapholdsToGrabber() catch |err| {
-        log.warn("hot reload: could not forward updated rules to skhd-grabber: {s}", .{@errorName(err)});
+        log.err("hot reload: could not forward updated rules to skhd-grabber: {s}", .{@errorName(err)});
     };
 
     // Note: We don't re-enable hot reload here because this function
     // might be called from within the hotload callback. Instead, we'll
     // update the watched files list when hot reload is already enabled.
 
-    log.info("Configuration reloaded successfully", .{});
+    log.warn("Configuration reloaded successfully", .{});
 }
 
 pub fn enableHotReload(self: *Skhd) !void {

--- a/src/skhd.zig
+++ b/src/skhd.zig
@@ -891,6 +891,12 @@ inline fn interceptSystemKey(event: c.CGEventRef, eventkey: *Hotkey.KeyPress) bo
 const SKHD_EVENT_MARKER: i64 = 0x736B6864; // "skhd" in hex
 
 inline fn forwardKey(target_key: Hotkey.KeyPress, _: c.CGEventRef) !void {
+    // Mouse buttons live in a separate keycode space (≥ 0x10000) and need
+    // CGEventCreateMouseEvent rather than CGEventCreateKeyboardEvent.
+    if (Keycodes.isMouseButton(target_key.key)) {
+        try postMouseClick(target_key);
+        return;
+    }
     // Check if this is an NX media key (requires different event type)
     if (target_key.flags.nx) {
         try postMediaKeyEvent(target_key.key);
@@ -924,6 +930,51 @@ inline fn forwardKey(target_key: Hotkey.KeyPress, _: c.CGEventRef) !void {
     // Post both key down and key up events
     c.CGEventPost(c.kCGSessionEventTap, key_down);
     c.CGEventPost(c.kCGSessionEventTap, key_up);
+}
+
+/// Synthesize a mouse-down + mouse-up at the current cursor position.
+/// Used for `... | mouse1` forwards. The cursor doesn't move; we just
+/// fire a click in place.
+inline fn postMouseClick(target_key: Hotkey.KeyPress) !void {
+    const button: u32 = target_key.key & 0xFF; // 1..5
+    const down_type: c.CGEventType, const up_type: c.CGEventType, const cg_button: c.CGMouseButton = switch (button) {
+        1 => .{ c.kCGEventLeftMouseDown, c.kCGEventLeftMouseUp, c.kCGMouseButtonLeft },
+        2 => .{ c.kCGEventRightMouseDown, c.kCGEventRightMouseUp, c.kCGMouseButtonRight },
+        else => .{ c.kCGEventOtherMouseDown, c.kCGEventOtherMouseUp, @intCast(button - 1) },
+    };
+
+    // CGEventCreate(NULL) returns an empty event whose location field is
+    // populated with the current cursor position — cheaper than a Cocoa
+    // round-trip via NSEvent.mouseLocation.
+    const probe = c.CGEventCreate(null);
+    if (probe == null) return error.FailedToProbeMouse;
+    defer c.CFRelease(probe);
+    const cursor = c.CGEventGetLocation(probe);
+
+    const source = c.CGEventSourceCreate(c.kCGEventSourceStateHIDSystemState);
+    if (source == null) return error.FailedToCreateEventSource;
+    defer c.CFRelease(source);
+
+    const down = c.CGEventCreateMouseEvent(source, down_type, cursor, cg_button);
+    if (down == null) return error.FailedToCreateMouseEvent;
+    defer c.CFRelease(down);
+
+    const up = c.CGEventCreateMouseEvent(source, up_type, cursor, cg_button);
+    if (up == null) return error.FailedToCreateMouseEvent;
+    defer c.CFRelease(up);
+
+    // Carry any modifier flags from the forward target so syntax like
+    // `key | cmd - mouse1` synthesizes a cmd-click rather than a plain click.
+    const target_flags = hotkeyFlagsToCGEventFlags(target_key.flags);
+    c.CGEventSetFlags(down, target_flags);
+    c.CGEventSetFlags(up, target_flags);
+
+    // Mark as self-generated so handleMouseDown re-entry skips them.
+    c.CGEventSetIntegerValueField(down, c.kCGEventSourceUserData, SKHD_EVENT_MARKER);
+    c.CGEventSetIntegerValueField(up, c.kCGEventSourceUserData, SKHD_EVENT_MARKER);
+
+    c.CGEventPost(c.kCGSessionEventTap, down);
+    c.CGEventPost(c.kCGSessionEventTap, up);
 }
 
 /// Synthesize and post a media key event (play, next, previous, etc.)
@@ -1222,7 +1273,12 @@ pub fn reloadConfig(self: *Skhd) !void {
         }
         return err;
     };
-    try parser.processLoadDirectives(&new_mappings);
+    parser.processLoadDirectives(&new_mappings) catch |err| {
+        if (parser.error_info) |parse_err| {
+            log.err("skhd: {}", .{parse_err});
+        }
+        return err;
+    };
 
     // Swap old mappings with new ones
     self.mappings.deinit();


### PR DESCRIPTION
## Summary

Adds `mouse1`–`mouse5` as both bindable triggers and synthesizable forward targets:

```
# As triggers
cmd - mouse1 : echo "cmd-click"
meh - mouse3 : open -a "Mission Control"
mouse4 -> : echo "back button"        # passthrough — click still reaches the app

# As forward targets (new in this PR)
fn_layer < return | mouse1            # in fn_layer, return = left-click
cmd - x | cmd - mouse1                # cmd-x → cmd-click
```

## Implementation

**Tokenizer/parser**: no schema changes. `mouse1`–`mouse5` slot into the existing `literal_keycode_str` table with synthetic `u32` keycodes ≥ `0x10000` — well above the keyboard `kVK_*` range. New `KEY_FIRST_MOUSE` constant bounds the implicit-nx range so mouse buttons don't pick up the nx flag. `Hotkey.KeyPress { flags, key }` is unchanged.

**Capture side** (\`src/skhd.zig\`): event-tap mask gains `kCGEventLeftMouseDown` / `RightMouseDown` / `OtherMouseDown`. `keyHandler` dispatches them to a new `handleMouseDown(event, n)` that mirrors `handleKeyDown` — same mode / marker / blacklist / cgflags pipeline, same `processHotkey` lookup. `OtherMouseDown` reads `kCGMouseEventButtonNumber` (0-based, 2..4 → mouse3..mouse5).

**Synthesis side**: `forwardKey` dispatches to a new `postMouseClick(target)` ahead of the existing media-key (NX) branch. `postMouseClick` reads the current cursor position via `CGEventCreate(NULL)` + `CGEventGetLocation`, builds matching down/up `CGEvent`s, carries modifier flags from the target through `CGEventSetFlags` (so `key | cmd - mouse1` is a cmd-click), and stamps `SKHD_EVENT_MARKER` so our own tap re-entry skips them.

## Bonus: better hot-reload diagnostics

While testing, `error.ParseErrorOccurred` was surfaced with no detail when the parse error was inside a `.load`-ed file. `reloadConfig` only printed `parser.error_info` for the top-level `parseWithPath`; `processLoadDirectives` now goes through the same logging path. So instead of:

\`\`\`
error(skhd): Failed to reload config: error.ParseErrorOccurred
\`\`\`

you now get:

\`\`\`
error(skhd): skhd: /…/builtin.skhdrc:98:12: error: Expected key, key hex, or literal near 'enter'
\`\`\`

## Out of scope

- Mouse-up / drag events (stateful, much bigger lift)
- Scroll-wheel events
- Mouse6+ (rare; can extend later)

## Trackpad gotcha (documented prominently in SYNTAX.md)

A no-modifier non-passthrough binding like `mouse1 : ...` consumes every left-click and effectively breaks the trackpad. Always pair with a modifier (`cmd - mouse1`) or use `->` passthrough unless you really mean it.

## Test plan

- [x] \`zig build test\` — all tests pass, including 2 new ones (`Keycodes` mouse-literal placement & synthetic-code property; `Parser` `cmd - mouse1` / `mouse3 ->` parses correctly with no implicit nx flag pollution)
- [x] \`zig build install-local -Doptimize=ReleaseFast\` — daemon restarts cleanly, parses real-world config including `fn_layer < return | mouse1`
- [x] Tested live: `fn_layer < return | mouse1` synthesizes a left-click at the cursor when triggered (QMK chord generates the keystroke that fires the layer rule)