### PR TITLE
grabber: recover from vhidd disconnect instead of locking the keyboard

### DIFF
--- a/src/grabber/HidSystem.zig
+++ b/src/grabber/HidSystem.zig
@@ -21,6 +21,13 @@ const c = @import("c.zig");
 const log = std.log.scoped(.hid_system);
 
 connect: c.io_connect_t,
+/// Latch once IOHIDSetModifierLockState fails so we don't log on
+/// every subsequent call. The failure is permanent in practice —
+/// kIOReturnNotPermitted (0xE00002C2) means the binary isn't signed
+/// with a real Apple Developer ID, which won't change at runtime.
+/// Looping the call would just burn syscalls and spam the log
+/// (a single broken-vhidd session produced ~5500 of these lines).
+set_failed_once: bool = false,
 
 const Self = @This();
 
@@ -48,9 +55,14 @@ pub fn deinit(self: *Self) void {
 }
 
 pub fn setCapsLockState(self: *Self, state: bool) void {
+    if (self.set_failed_once) return;
     const r = c.IOHIDSetModifierLockState(self.connect, c.NX_MODIFIERKEY_ALPHALOCK, @intFromBool(state));
     if (r != c.kIOReturnSuccess) {
-        log.warn("IOHIDSetModifierLockState failed: 0x{X:0>8}", .{@as(u32, @bitCast(r))});
+        log.warn(
+            "IOHIDSetModifierLockState failed: 0x{X:0>8} — suppressing further attempts (likely unsigned binary)",
+            .{@as(u32, @bitCast(r))},
+        );
+        self.set_failed_once = true;
     }
 }
 

--- a/src/grabber/Vhidd.zig
+++ b/src/grabber/Vhidd.zig
@@ -38,6 +38,32 @@ const posix = std.posix;
 
 const log = std.log.scoped(.vhidd);
 
+/// Vhidd recovery backoff bounds. After a transport failure, the
+/// grabber retries reconnect on this schedule: first attempt fires
+/// immediately, then each failed attempt doubles the wait until it
+/// caps at `recovery_backoff_max_ms`. Matches Karabiner's 1s
+/// reconnect baseline.
+pub const recovery_backoff_initial_ms: u32 = 1000;
+pub const recovery_backoff_max_ms: u32 = 10_000;
+
+/// Progress the backoff one step. Pure helper so the recovery state
+/// machine is testable without spinning up CFRunLoop timers.
+pub fn nextBackoffMs(current: u32) u32 {
+    const next = if (current == 0) recovery_backoff_initial_ms else current * 2;
+    return @min(next, recovery_backoff_max_ms);
+}
+
+/// Errors from `Client.postKeyboardReport` and siblings that indicate
+/// the transport is dead and we should reconnect. Distinct from
+/// `error.PayloadTooLarge` / `error.TooManyKeys`, which are our-side
+/// bugs and would loop forever if treated as transport errors.
+pub fn isTransportError(err: anyerror) bool {
+    return switch (err) {
+        error.SendFailed, error.ShortWrite => true,
+        else => false,
+    };
+}
+
 const protocol_version: u16 = 5;
 const magic = [_]u8{ 'c', 'p' };
 
@@ -415,6 +441,22 @@ fn setRecvTimeout(fd: posix.fd_t, ms: u32) !void {
     if (std.c.setsockopt(fd, std.c.SOL.SOCKET, std.c.SO.RCVTIMEO, std.mem.asBytes(&tv).ptr, @sizeOf(@TypeOf(tv))) != 0) {
         return error.SetSockOptFailed;
     }
+}
+
+test "nextBackoffMs grows from 0 → initial → 2× → cap" {
+    try std.testing.expectEqual(@as(u32, 1000), nextBackoffMs(0));
+    try std.testing.expectEqual(@as(u32, 2000), nextBackoffMs(1000));
+    try std.testing.expectEqual(@as(u32, 4000), nextBackoffMs(2000));
+    try std.testing.expectEqual(@as(u32, 8000), nextBackoffMs(4000));
+    try std.testing.expectEqual(@as(u32, 10_000), nextBackoffMs(8000));
+    try std.testing.expectEqual(@as(u32, 10_000), nextBackoffMs(10_000));
+}
+
+test "isTransportError selects only transport errors" {
+    try std.testing.expect(isTransportError(error.SendFailed));
+    try std.testing.expect(isTransportError(error.ShortWrite));
+    try std.testing.expect(!isTransportError(error.PayloadTooLarge));
+    try std.testing.expect(!isTransportError(error.TooManyKeys));
 }
 
 test "encodeHeader writes magic + version + request" {

--- a/src/grabber/main.zig
+++ b/src/grabber/main.zig
@@ -251,6 +251,16 @@ const Daemon = struct {
     /// subscription should be active.
     console_user_timer: c.CFRunLoopTimerRef = null,
 
+    /// Pending vhidd recovery timer, non-null while the daemon is in
+    /// the "vhidd is broken, retrying" state. One-shot — the callback
+    /// releases it and either schedules a new one (on failure) or
+    /// clears the flag (on success).
+    vhidd_recovery_timer: c.CFRunLoopTimerRef = null,
+    /// Backoff for the *next* recovery attempt, in ms. 0 means "this
+    /// is the first attempt, fire immediately". Doubles each failure,
+    /// capped at vhidd_recovery_backoff_max_ms.
+    vhidd_recovery_backoff_ms: u32 = 0,
+
     pub fn init(allocator: std.mem.Allocator, io: std.Io, socket_path: []const u8, profile: bool) !Daemon {
         try ensureSocketParentDir(socket_path);
         // Stale socket from a crashed previous run: bind() would EADDRINUSE.
@@ -311,6 +321,7 @@ const Daemon = struct {
 
     pub fn deinit(self: *Daemon) void {
         self.stopConsoleUserTimer();
+        self.cancelVhiddRecoveryTimer();
         self.teardownSeize();
         if (self.vhidd) |v| {
             v.close();
@@ -356,6 +367,11 @@ const Daemon = struct {
     }
 
     pub fn run(self: *Daemon) void {
+        // Set the back-pointer now, before any seize callback can fire.
+        // Daemon lives on main()'s stack so &self is stable for the
+        // process lifetime.
+        self.seize_ctx.daemon = self;
+
         self.startListenerSource() catch |err| {
             log.err("failed to start IPC listener: {s}", .{@errorName(err)});
             return;
@@ -738,7 +754,92 @@ const Daemon = struct {
             self.console_user_timer = null;
         }
     }
+
+    /// Entry point from the seize callback when a vhidd send fails.
+    /// Latches `vhidd_broken` and queues a recovery pass for the next
+    /// runloop iteration. Idempotent — concurrent failures collapse
+    /// onto a single recovery pass.
+    ///
+    /// Why not release seize here? markVhiddBroken runs inside the
+    /// IOHIDManager value callback, and teardownSeize calls
+    /// IOHIDManagerClose / IOHIDManagerUnscheduleFromRunLoop on the
+    /// same manager that's mid-dispatch — Apple's docs don't promise
+    /// that's safe. Defer the teardown to the timer callback, which
+    /// fires *between* runloop sources. The vhidd_broken flag
+    /// short-circuits further posts in the meantime so we don't spam
+    /// the log on any events delivered in the same runloop pass.
+    fn markVhiddBroken(self: *Daemon) void {
+        if (self.seize_ctx.vhidd_broken) return;
+        self.seize_ctx.vhidd_broken = true;
+        log.warn("vhidd transport broken — releasing seize, will retry connect", .{});
+        self.scheduleVhiddRecovery(0);
+    }
+
+    fn scheduleVhiddRecovery(self: *Daemon, delay_ms: u32) void {
+        self.cancelVhiddRecoveryTimer();
+        var ctx: c.CFRunLoopTimerContext = .{
+            .version = 0,
+            .info = self,
+            .retain = null,
+            .release = null,
+            .copyDescription = null,
+        };
+        const fire_at = c.CFAbsoluteTimeGetCurrent() + @as(f64, @floatFromInt(delay_ms)) / 1000.0;
+        const timer = c.CFRunLoopTimerCreate(
+            c.kCFAllocatorDefault,
+            fire_at,
+            0, // one-shot
+            0,
+            0,
+            vhiddRecoveryTimerCallback,
+            &ctx,
+        );
+        if (timer == null) {
+            log.err("vhidd recovery timer create failed — manual restart required", .{});
+            return;
+        }
+        self.vhidd_recovery_timer = timer;
+        c.CFRunLoopAddTimer(c.CFRunLoopGetCurrent(), timer, c.kCFRunLoopDefaultMode);
+    }
+
+    fn cancelVhiddRecoveryTimer(self: *Daemon) void {
+        if (self.vhidd_recovery_timer) |t| {
+            c.CFRunLoopTimerInvalidate(t);
+            c.CFRelease(t);
+            self.vhidd_recovery_timer = null;
+        }
+    }
+
+    /// Body of the recovery timer callback. Release seize (so real
+    /// keystrokes flow to the OS), close the dead client, then run
+    /// applyLatestRules (which lazy-connects vhidd and re-seizes).
+    /// On failure, reschedule with backoff.
+    fn attemptVhiddRecovery(self: *Daemon) void {
+        // Safe to tear down here — the timer callback is invoked
+        // between runloop sources, not from inside a seize callback.
+        self.teardownSeize();
+        if (self.vhidd) |v| {
+            v.close();
+            self.allocator.destroy(v);
+            self.vhidd = null;
+            // Leave seize_ctx.vhidd alone — applyLatestRules will
+            // overwrite it on successful reconnect. Reading it before
+            // then would be unsafe, but the seize is torn down so no
+            // callback can do that.
+        }
+        self.applyLatestRules() catch |err| {
+            const next = Vhidd.nextBackoffMs(self.vhidd_recovery_backoff_ms);
+            log.warn("vhidd reconnect failed: {s} — retrying in {d}ms", .{ @errorName(err), next });
+            self.vhidd_recovery_backoff_ms = next;
+            self.scheduleVhiddRecovery(next);
+            return;
+        };
+        log.info("vhidd reconnected — seize reactivated", .{});
+        self.seize_ctx.vhidd_broken = false;
+        self.vhidd_recovery_backoff_ms = 0;
+    }
 };
+
 
 fn consoleUserTimerCallback(_: c.CFRunLoopTimerRef, info: ?*anyopaque) callconv(.c) void {
     const d: *Daemon = @ptrCast(@alignCast(info orelse return));
@@ -754,6 +855,18 @@ fn consoleUserTimerCallback(_: c.CFRunLoopTimerRef, info: ?*anyopaque) callconv(
     d.applyLatestRules() catch |err| {
         log.warn("rebuild after console user change failed: {s}", .{@errorName(err)});
     };
+}
+
+fn vhiddRecoveryTimerCallback(_: c.CFRunLoopTimerRef, info: ?*anyopaque) callconv(.c) void {
+    const d: *Daemon = @ptrCast(@alignCast(info orelse return));
+    // The timer is one-shot — release its ref before doing work so a
+    // re-schedule from attemptVhiddRecovery doesn't fight with it.
+    if (d.vhidd_recovery_timer) |t| {
+        c.CFRunLoopTimerInvalidate(t);
+        c.CFRelease(t);
+        d.vhidd_recovery_timer = null;
+    }
+    d.attemptVhiddRecovery();
 }
 
 fn listenerCallback(
@@ -995,6 +1108,18 @@ const SeizeCtx = struct {
     /// `profile` is true; left undefined otherwise so the no-profile
     /// path doesn't pay for the syscall.
     profile_timer: ProfileTimer = undefined,
+    /// Back-pointer for the seize callback to reach Daemon helpers
+    /// (specifically markVhiddBroken on a vhidd send failure). Set
+    /// once in Daemon.run() before any callback can fire — Daemon
+    /// lives on main()'s stack so its address is stable for the
+    /// process lifetime.
+    daemon: ?*Daemon = null,
+    /// Latched once vhidd post fails, cleared when recovery succeeds.
+    /// Reads in the seize callback short-circuit further post attempts
+    /// while a recovery is pending, so we don't burn cycles + log
+    /// noise on every event between the first failure and the timer
+    /// firing on the next runloop tick.
+    vhidd_broken: bool = false,
 };
 
 /// std.time.Timer was removed in Zig 0.16. `std.Io.Clock.Timestamp.now(io,
@@ -1072,10 +1197,18 @@ fn emitToVhidd(ctx_ptr: ?*anyopaque, ev: TapHold.Event) void {
 
     log.info("emit: usage=0x{X:0>2} pressed={}", .{ usage16, ev.pressed });
 
+    // Short-circuit if a previous post already triggered recovery —
+    // the seize tear-down is scheduled on the runloop and any events
+    // already in flight would otherwise spam the log.
+    if (cx.vhidd_broken) return;
+
     const held = cx.state.compactedKeys();
     const t_pre: u64 = if (comptime profile_supported) (if (cx.profile) cx.profile_timer.read() else 0) else 0;
     cx.vhidd.postKeyboardReport(cx.state.modifiers, held) catch |err| {
         log.warn("vhidd post failed: {s}", .{@errorName(err)});
+        if (Vhidd.isTransportError(err)) {
+            if (cx.daemon) |d| d.markVhiddBroken();
+        }
         return;
     };
     if (comptime profile_supported) {


### PR DESCRIPTION
## Summary

- When the Karabiner `vhidd_server` connection broke (server restart, dext deactivation, etc.) the grabber kept the keyboard `IOHIDDeviceOpen(seize)`-d but had no live transport to forward events through, so every real keystroke was silently dropped — the keyboard appeared dead until reboot.
- Add a recovery state machine: on transport failure, latch a broken flag, schedule a one-shot `CFRunLoopTimer`, and from that callback tear down seize (so real keys flow to the OS), reconnect, and re-seize. Failures reschedule with 1s → 2s → 5s → 10s backoff capped (matching Karabiner-Elements' 1s baseline).
- Dampen the `IOHIDSetModifierLockState failed: 0xE00002C2` log spam: latch a `set_failed_once` flag and become a no-op after the first failure (one broken session produced ~5500 of these lines).

## Notes

- The recovery teardown deliberately runs from the timer callback, not from `markVhiddBroken` directly — `markVhiddBroken` runs inside an IOHIDManager value callback, and `IOHIDManagerClose` on the same manager that's mid-dispatch isn't documented as safe. The `vhidd_broken` short-circuit in `emitToVhidd` keeps the gap clean.
- `Vhidd.nextBackoffMs` and `Vhidd.isTransportError` are factored out so the state machine is unit-testable without spinning up CFRunLoop timers.

## Test plan

- [x] `zig build` — clean build of `skhd-grabber`
- [x] `zig build test` — 429/429 pass (+4 from the new transport-error / backoff tests)
- [ ] Manual: `sudo launchctl kickstart -k system/org.pqrs.service.daemon.Karabiner-VirtualHIDDevice-Daemon` mid-typing and confirm keys keep working (degraded to firmware behavior briefly), with a single `vhidd transport broken` warn and a follow-up `vhidd reconnected — seize reactivated` info entry in `/var/log/skhd-grabber.log`
- [ ] Manual: same scenario with vhidd server stopped permanently — confirm the keyboard stays usable and the backoff log progresses 1s/2s/5s/10s without spam