### PR TITLE
grabber: harden vhidd recovery + switch tap to cask

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,30 +246,26 @@ jobs:
         X86_64_SHA=$(shasum -a 256 skhd-x86_64-macos.tar.gz | awk '{print $1}')
         echo "x86_64_sha=${X86_64_SHA}" >> $GITHUB_OUTPUT
 
-    - name: Update Formula
+    - name: Update Cask
       env:
         VERSION: ${{ steps.release.outputs.version }}
         ARM64_SHA: ${{ steps.release.outputs.arm64_sha }}
-        X86_64_SHA: ${{ steps.release.outputs.x86_64_sha }}
       run: |
         cd homebrew-tap
 
-        # Update version line if present (the formula may scan version from
-        # URL instead). No-op when missing.
-        sed -i "s/version \".*\"/version \"${VERSION}\"/" Formula/skhd-zig.rb
-
-        sed -i -E "s|download/v[0-9.]+(-[A-Za-z0-9]+)?/skhd-arm64|download/v${VERSION}/skhd-arm64|" Formula/skhd-zig.rb
-        sed -i "/arm64-macos.tar.gz/,/sha256/ s/sha256 \".*\"/sha256 \"${ARM64_SHA}\"/" Formula/skhd-zig.rb
-
-        sed -i -E "s|download/v[0-9.]+(-[A-Za-z0-9]+)?/skhd-x86_64|download/v${VERSION}/skhd-x86_64|" Formula/skhd-zig.rb
-        sed -i "/x86_64-macos.tar.gz/,/sha256/ s/sha256 \".*\"/sha256 \"${X86_64_SHA}\"/" Formula/skhd-zig.rb
+        # The cask's `url` interpolates `#{version}`, so bumping the version
+        # line automatically rewrites the download URL — no separate URL
+        # rewrite needed. Only one `sha256` line (arm64-only cask), so a plain
+        # substitution is unambiguous.
+        sed -i "s/version \".*\"/version \"${VERSION}\"/" Casks/skhd-zig.rb
+        sed -i "s/sha256 \".*\"/sha256 \"${ARM64_SHA}\"/" Casks/skhd-zig.rb
 
     - name: Commit and push
       run: |
         cd homebrew-tap
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
-        git add Formula/skhd-zig.rb
+        git add Casks/skhd-zig.rb
         git commit -m "Update skhd-zig to v${{ steps.release.outputs.version }}"
         git push
 

--- a/docs/superpowers/specs/2026-05-22-cask-distribution-and-v0.1.4-release-design.md
+++ b/docs/superpowers/specs/2026-05-22-cask-distribution-and-v0.1.4-release-design.md
@@ -1,0 +1,197 @@
+# Design: ship v0.1.4 + switch distribution to a Homebrew cask
+
+Date: 2026-05-22
+Status: approved (pending spec review)
+
+## Background
+
+Two things ship together:
+
+1. **A grabber bug fix (already implemented and tested in this branch).** The
+   `skhd-grabber` daemon seizes the physical keyboard and replays keystrokes
+   through Karabiner's virtual HID device (`vhidd`). When the `vhidd` transport
+   died, the grabber kept the keyboard seized while every replay was dropped — a
+   dead keyboard. Two changes fix it:
+   - `src/grabber/Vhidd.zig`: `isTransportError` was an over-narrow allowlist
+     (`SendFailed`/`ShortWrite` only). It now treats *any* post error as
+     transport-fatal except our-side logic bugs (`PayloadTooLarge`,
+     `TooManyKeys`), so `ConnectionResetByPeer` / `BrokenPipe` / `Unexpected`
+     trigger recovery instead of being ignored.
+   - `src/grabber/main.zig`: `applyLatestRules` now tears down the seize
+     *before* the (blocking, up-to-5s) `vhidd` connect, so the physical keyboard
+     is never seized while we wait on `vhidd`.
+
+   Verified locally: agent `0.1.4-dev` + grabber running from
+   `/Applications/skhd.app`, keyboard responsive, no regression.
+
+2. **A distribution change.** Today `skhd.zig` is distributed as a Homebrew
+   **formula** (`jackielii/homebrew-tap` → `Formula/skhd-zig.rb`) that downloads
+   a pre-built `skhd.app` tarball, installs it into the Cellar, and asks users to
+   manually `ln -sfn` the bundle into `/Applications`. Since the release artifact
+   is already an `.app` bundle, a **cask** is the natural fit: it installs to
+   `/Applications` automatically.
+
+## Constraint: no Apple Developer ID
+
+There is no Developer ID and no notarization. Releases are signed with a
+self-signed `skhd-cert` (stored as a CI secret; `TeamIdentifier=not set`).
+
+Implication for a cask: cask-downloaded apps receive the `com.apple.quarantine`
+attribute and Gatekeeper would block an un-notarized app. The accepted
+workaround for an unsigned cask in a personal tap is a `postflight` that strips
+the quarantine bit. Net behavior then equals today's formula: the app runs, and
+TCC grants (Accessibility / Input Monitoring) remain **manual one-time grants**
+keyed to the self-signed cert. This is unchanged from the status quo — the cask
+only adds the `/Applications` placement.
+
+## Decisions
+
+- **Cask token: `skhd-zig`** (unchanged from the formula token).
+  - The command users type is `skhd` regardless of token, because a `binary`
+    stanza symlinks `skhd.app/Contents/MacOS/skhd` onto `PATH`. The token only
+    matters at install time.
+  - Keeping `skhd-zig` means new users run the **same** command they always
+    have: `brew install skhd-zig`. With no formula by that name but a cask by
+    that name, Homebrew falls back automatically ("No available formula …; found
+    a cask named 'skhd-zig' instead") and installs the cask — no `--cask` flag
+    required.
+  - `skhd-zig` has zero collision with the original C `skhd`
+    (`koekeishiya/formulae/skhd`), which was the only naming risk considered.
+- **Replace the formula entirely** — delete `Formula/skhd-zig.rb`, add
+  `Casks/skhd-zig.rb`.
+- **arm64-only**, matching the formula's paused-Intel stance. The release still
+  produces an x86_64 tarball, but the cask ignores it.
+- **Grabber + Karabiner dext install stays a runtime `sudo skhd --install-grabber`
+  step in caveats** — not bundled as a cask `pkg`. Same as today.
+- **Land the fix via branch → PR → merge to `main`**, then tag `v0.1.4` from
+  `main` (consistent with the repo's PR history, e.g. #40/#41, and runs CI).
+
+## The cask: `homebrew-tap/Casks/skhd-zig.rb`
+
+Representative structure (exact `macos:` minimum and `zap`/`uninstall` paths
+finalized during implementation):
+
+```ruby
+cask "skhd-zig" do
+  version "0.1.4"
+  sha256 "<arm64 tarball sha256>"
+
+  url "https://github.com/jackielii/skhd.zig/releases/download/v#{version}/skhd-arm64-macos.tar.gz"
+  name "skhd.zig"
+  desc "Simple hotkey daemon for macOS, written in Zig"
+  homepage "https://github.com/jackielii/skhd.zig"
+
+  depends_on arch: :arm64
+  depends_on macos: ">= :big_sur"
+
+  app "skhd.app"
+  binary "#{appdir}/skhd.app/Contents/MacOS/skhd"
+
+  # No Developer ID / notarization: strip the download quarantine so the
+  # self-signed bundle runs (TCC grants remain manual, same as the formula).
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/skhd.app"]
+  end
+
+  uninstall launchctl: "com.jackielii.skhd",
+            quit:      "com.jackielii.skhd"
+
+  caveats <<~EOS
+    Configuration:
+      touch ~/.config/skhd/skhdrc
+
+    Setup (idempotent):
+      skhd --start-service
+      # Prompts for Accessibility + Input Monitoring on first launch. If your
+      # config uses .remap / .taphold / fn_layer rules, also prompts (sudo) to
+      # install skhd-grabber + the Karabiner-DriverKit-VirtualHIDDevice .pkg.
+      skhd --status
+
+    Full teardown of the root grabber (cask uninstall can't sudo):
+      sudo skhd --uninstall-grabber
+
+    Logs:
+      ~/Library/Logs/skhd.log    (agent)
+      /var/log/skhd-grabber.log  (grabber, if installed)
+  EOS
+
+  zap trash: [
+    "~/Library/Logs/skhd.log",
+  ]
+end
+```
+
+Open implementation detail: the root `skhd-grabber` LaunchDaemon can't be torn
+down by `brew uninstall --cask` without a sudo prompt, so full grabber removal
+stays a documented `sudo skhd --uninstall-grabber` step in caveats rather than
+an `uninstall script:` directive.
+
+## Release automation: `skhd.zig/.github/workflows/release.yml`
+
+The `update-homebrew` job currently `sed`s `Formula/skhd-zig.rb` for version,
+url, and both arm64 + x86_64 sha256. Change it to:
+
+- `git add` / `sed` target → `Casks/skhd-zig.rb`.
+- Keep the version + url + **arm64** sha256 substitutions (the cask's `version`,
+  `url`, and `sha256` lines).
+- Drop the x86_64 url + sha256 substitutions (cask is arm64-only).
+- Commit message and asset download logic unchanged.
+
+The job's pre-release skip (`-alpha`/`-beta`/`-rc`) and tap checkout are
+unchanged.
+
+## Execution sequence
+
+Ordering matters: the auto-bump job only edits an **existing** file, so the cask
+must exist in the tap before the v0.1.4 release runs.
+
+1. **`skhd.zig`**: branch → PR with the grabber fix + the `release.yml`
+   `update-homebrew` change → merge to `main`.
+2. **`homebrew-tap`**: add `Casks/skhd-zig.rb` (correct structure so the `sed`
+   patterns match; initial version/sha can be the v0.1.3 values — the release
+   job overwrites them), delete `Formula/skhd-zig.rb`, commit, push.
+3. **`skhd.zig`**: tag `v0.1.4` on `main`, push the tag → `release.yml` builds,
+   self-signs, publishes the GitHub release, then the `update-homebrew` job
+   `sed`s `Casks/skhd-zig.rb` to v0.1.4 + the real arm64 sha256 and pushes.
+4. **Verify** on this machine:
+   `brew untap jackielii/tap; brew install --cask jackielii/tap/skhd-zig`
+   (or `brew install jackielii/tap/skhd-zig` to confirm the formula→cask
+   fallback), then `skhd --start-service` + `skhd --status`.
+
+Note: pushing the `v0.1.4` tag is an outward-facing, hard-to-reverse action
+(publishes a public release). Confirm before pushing.
+
+## Migration for existing users
+
+Document in the v0.1.4 release notes:
+
+```
+brew uninstall skhd-zig        # removes the old formula
+brew install skhd-zig          # installs the cask (auto-fallback) → /Applications/skhd.app
+```
+
+`brew upgrade` will NOT auto-convert an installed formula into a cask, so the
+uninstall + reinstall is required once.
+
+## Non-goals (YAGNI)
+
+- No Developer ID certificate or notarization.
+- No `pkg`-based grabber/dext install inside the cask.
+- No Intel/x86_64 cask variant.
+- No change to how the grabber/agent themselves work (beyond the bug fix).
+
+## Risks
+
+- **Quarantine strip on newer macOS.** `xattr -dr com.apple.quarantine` in
+  `postflight` is the standard unsigned-cask workaround, but Gatekeeper on
+  recent macOS is stricter. Mitigation: the app is launched by launchd /
+  SMAppService, not Finder double-click, which is the lenient path; verified
+  working locally via the equivalent `install-local` overlay.
+- **TCC re-grant on the cert change.** Switching from the CI-signed bundle to a
+  cask-delivered bundle keyed to the same self-signed `skhd-cert` may require a
+  one-time Accessibility / Input Monitoring re-grant — same one-time cost the
+  formula already has, documented in caveats.
+- **First-cask bootstrap.** If the cask file is missing from the tap when the
+  release job runs, the `sed` no-ops/fails silently. Step 2 must precede step 3.
+```

--- a/src/grabber/Vhidd.zig
+++ b/src/grabber/Vhidd.zig
@@ -53,14 +53,22 @@ pub fn nextBackoffMs(current: u32) u32 {
     return @min(next, recovery_backoff_max_ms);
 }
 
-/// Errors from `Client.postKeyboardReport` and siblings that indicate
-/// the transport is dead and we should reconnect. Distinct from
-/// `error.PayloadTooLarge` / `error.TooManyKeys`, which are our-side
-/// bugs and would loop forever if treated as transport errors.
+/// Whether a failed `Client.postKeyboardReport` (or sibling) means the
+/// transport is dead and we should tear down the seize + reconnect.
+///
+/// Default-true: a post that didn't go through leaves the pipe in an
+/// unknown state, so we treat *any* error as transport-fatal — the
+/// exact errno the OS surfaces varies (`SendFailed`, `ShortWrite`,
+/// `ConnectionResetByPeer` when the Karabiner daemon closes the socket,
+/// `BrokenPipe`, `Unexpected`, …) and an over-narrow allowlist is what
+/// let the grabber keep the keyboard seized while every replay was
+/// silently dropped. The only exclusions are our-side logic bugs that a
+/// reconnect cannot fix: a malformed/oversized report would otherwise
+/// drive an endless recover loop.
 pub fn isTransportError(err: anyerror) bool {
     return switch (err) {
-        error.SendFailed, error.ShortWrite => true,
-        else => false,
+        error.PayloadTooLarge, error.TooManyKeys => false,
+        else => true,
     };
 }
 
@@ -452,9 +460,20 @@ test "nextBackoffMs grows from 0 → initial → 2× → cap" {
     try std.testing.expectEqual(@as(u32, 10_000), nextBackoffMs(10_000));
 }
 
-test "isTransportError selects only transport errors" {
+test "isTransportError treats any post error as transport-fatal except our-side logic bugs" {
+    // A failed post means the pipe is unusable — reconnect, regardless
+    // of which errno the OS surfaced. The original list was too narrow:
+    // `ConnectionResetByPeer` (Karabiner daemon closed the socket) and
+    // friends slipped through, so `markVhiddBroken` never fired and the
+    // grabber kept the keyboard seized while every replay was dropped.
     try std.testing.expect(isTransportError(error.SendFailed));
     try std.testing.expect(isTransportError(error.ShortWrite));
+    try std.testing.expect(isTransportError(error.ConnectionResetByPeer));
+    try std.testing.expect(isTransportError(error.BrokenPipe));
+    try std.testing.expect(isTransportError(error.Unexpected));
+
+    // Our-side logic bugs: a reconnect can't fix a malformed report, so
+    // these must NOT trigger an endless recover loop.
     try std.testing.expect(!isTransportError(error.PayloadTooLarge));
     try std.testing.expect(!isTransportError(error.TooManyKeys));
 }

--- a/src/grabber/main.zig
+++ b/src/grabber/main.zig
@@ -587,7 +587,17 @@ const Daemon = struct {
             log.info("  remap[{d}]: src=0x{X:0>2} → dst=0x{X:0>2}", .{ i, rm.src_usage, rm.dst_usage });
         }
 
-        // Lazy vhidd init on first apply.
+        // Release the physical keyboard FIRST. The seize must never be
+        // held across the (potentially blocking, up-to-5s) vhidd connect
+        // below: a stale or dead vhidd would otherwise leave every
+        // keystroke captured-but-undeliverable — a dead keyboard. With
+        // the seize torn down the keyboard falls back to the real HID
+        // path until we re-seize at the end of this function. HidSeize is
+        // also a one-process singleton, so it must be released before the
+        // HidSeize.init below runs again.
+        self.teardownSeize();
+
+        // Lazy vhidd init on first apply (or after a recovery nulled it).
         if (self.vhidd == null) {
             log.info("connecting to vhidd_server", .{});
             const v = try self.allocator.create(Vhidd.Client);
@@ -608,10 +618,7 @@ const Daemon = struct {
         // owners any more).
         self.layer_ctx.stream = if (has_layer_rule) sub.stream else null;
 
-        // Tear down old seize + slots before allocating new ones.
-        // HidSeize is the singleton (one-process IOHIDManager); we
-        // must release it before calling HidSeize.init again.
-        self.teardownSeize();
+        // (Seize already torn down above, before the vhidd connect.)
 
         // Build slots and seize as locals first. Don't expose to
         // `self` until everything's wired up — otherwise a failure


### PR DESCRIPTION
Two changes that ship together as v0.1.4.

## 1. Grabber: harden vhidd recovery (the real fix)

The grabber would keep the physical keyboard seized while every re-injection to the Karabiner virtual HID daemon failed silently — a dead keyboard until `launchctl bootout`. Two gaps:

- `isTransportError` allowlist was too narrow (`SendFailed`/`ShortWrite` only). `ConnectionResetByPeer`, `BrokenPipe`, `Unexpected` — exactly the errors the OS surfaces when the daemon resets — fell through and recovery never fired. Flip the classification: any post error is transport-fatal except our-side logic bugs (`PayloadTooLarge`, `TooManyKeys`) that a reconnect can't fix.
- `applyLatestRules` ran `teardownSeize` *after* the (blocking up-to-5s) vhidd connect. On a fresh apply with a stale seize and a dead vhidd, the old seize was held for the whole 5s timeout. Move `teardownSeize` ahead of the vhidd connect so the physical keyboard is never seized while we're blocked (re)connecting.

Unit test in `Vhidd.zig` extended (RED→GREEN).

## 2. Release: switch tap auto-bump from formula to cask

v0.1.4 ships as a Homebrew cask. The cask installs `skhd.app` directly into `/Applications` — the formula had to ask users to `ln -sfn` it manually.

`update-homebrew` job retargeted to `Casks/skhd-zig.rb`. The cask's `url` interpolates `#{version}`, so bumping `version` rewrites the URL automatically (no separate URL sed). Cask is arm64-only, so the x86_64 sed steps go away.

Sequencing, the no-Developer-ID quarantine trade-off, and migration notes live in `docs/superpowers/specs/2026-05-22-cask-distribution-and-v0.1.4-release-design.md`.

## Verified locally

- Tests green (`zig build test`).
- Built ReleaseFast `skhd.app`, signed, tarred, dropped into a temporary tap with a `file://` URL, and confirmed `brew install jackielii/tap/skhd-zig` (no `--cask`) takes the formula→cask fallback and installs the app to `/Applications` with the postflight quarantine strip applied. Agent + grabber start cleanly from the cask bundle; no permission or seize errors.

The `homebrew-tap` companion change (add `Casks/skhd-zig.rb`, delete `Formula/skhd-zig.rb`) is staged in its repo and will be pushed before the `v0.1.4` tag.