### PR TITLE
Add microphone usage description to app bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         test -f skhd.app/Contents/MacOS/skhd-grabber
         test -f skhd.app/Contents/Info.plist
         grep -q "<string>com.jackielii.skhd</string>" skhd.app/Contents/Info.plist
+        grep -q "<key>NSMicrophoneUsageDescription</key>" skhd.app/Contents/Info.plist
         plutil -lint skhd.app/Contents/Info.plist
 
     - name: Create tarball

--- a/assets/Info.plist.template
+++ b/assets/Info.plist.template
@@ -24,6 +24,8 @@
     <true/>
     <key>LSUIElement</key>
     <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Allow skhd to launch hotkeys that record audio, such as voice transcription commands.</string>
     <key>NSHumanReadableCopyright</key>
     <string>Released under the MIT License.</string>
 </dict>


### PR DESCRIPTION
## Summary

This supports hotkey-triggered voice transcription workflows such as [`agent-cli`](https://github.com/basnijholt/agent-cli) by adding `NSMicrophoneUsageDescription` to the generated `skhd.app` bundle. It also extends the bundle-layout CI check to verify that the key is present.

## Why

`skhd` itself is not an audio recorder, but users can bind hotkeys that launch commands which record audio. One concrete use case is an [`agent-cli`](https://github.com/basnijholt/agent-cli) voice transcription hotkey:

```skhd
cmd + shift - r : ~/.config/skhd/toggle-transcription.sh
```

That script launches the transcription command via Homebrew Python. On macOS, TCC can attribute the microphone request from that child process back to the responsible launcher bundle, `com.jackielii.skhd`. Without an `NSMicrophoneUsageDescription` in the official app bundle, macOS may not show a useful Microphone permission prompt or may deny access to the input device, even though the hotkey command itself is triggered correctly.

The observed failure mode was:

- the skhd hotkey fired and displayed a terminal notification
- the transcription command started and wrote a WAV file
- the WAV contained digital silence (`max_volume: -91 dB`)
- system logs showed TCC handling a microphone request attributed to `com.jackielii.skhd` with the requesting process as Homebrew Python
- `coreaudiod` logged: `Client is not granted access to the input device.`

Adding this key does not grant microphone access by itself. It gives macOS the required purpose string for the app bundle so users can grant access when a skhd-launched command needs microphone input.

## Validation

Run locally with Zig 0.16.0:

- `zig build test`
- `zig build`
- `bash -n scripts/make-app.sh && bash -n scripts/codesign.sh && bash -n scripts/release.sh`
- `zig build app`
- Verified generated `zig-out/skhd.app/Contents/Info.plist` with `plutil -lint`
- Verified generated bundle contains `NSMicrophoneUsageDescription`
- Verified app bundle layout for `Debug`, `ReleaseSafe`, `ReleaseFast`, and `ReleaseSmall`