### PR TITLE
matching: handle FIFO built-in keyboards with no IOKit VID/PID

### DIFF
--- a/src/DeviceCheck.zig
+++ b/src/DeviceCheck.zig
@@ -67,11 +67,13 @@ extern fn IOHIDDeviceGetProperty(device: IOHIDDeviceRef, key: CFStringRef) ?*any
 const kIOHIDVendorIDKey: [*:0]const u8 = "VendorID";
 const kIOHIDProductIDKey: [*:0]const u8 = "ProductID";
 const kIOHIDProductKey: [*:0]const u8 = "Product";
-/// IOKit device-level usage match keys. `Primary*` works too, but the
-/// `Device*` variants are what `IOHIDManagerSetDeviceMatching*` keys on
-/// per Apple's `IOHIDKeys.h` headers.
-const kIOHIDDeviceUsagePageKey: [*:0]const u8 = "DeviceUsagePage";
-const kIOHIDDeviceUsageKey: [*:0]const u8 = "DeviceUsage";
+/// IOKit usage match keys. We use the `Primary*` variants here for
+/// consistency with `HidSeize.setMatches` and `Hidutil.buildMatching`,
+/// so all three matching paths see the same set of devices for a given
+/// (vendor, product). `Device*` would also work for matching but can
+/// diverge on composite devices.
+const kIOHIDPrimaryUsagePageKey: [*:0]const u8 = "PrimaryUsagePage";
+const kIOHIDPrimaryUsageKey: [*:0]const u8 = "PrimaryUsage";
 
 /// HID usage page 0x01 (Generic Desktop), usage 0x06 (Keyboard) —
 /// the standard "this device is a keyboard" pair.
@@ -91,28 +93,56 @@ pub fn isPresent(vendor: u32, product: u32) bool {
     if (dicts == null) return false;
     defer CFRelease(dicts);
 
-    const dict = CFDictionaryCreateMutable(kCFAllocatorDefault, 2, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+    const dict = CFDictionaryCreateMutable(kCFAllocatorDefault, 4, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     if (dict == null) return false;
     defer CFRelease(dict);
 
-    const v_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDVendorIDKey, kCFStringEncodingUTF8);
-    if (v_key == null) return false;
-    defer CFRelease(v_key);
-    const p_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDProductIDKey, kCFStringEncodingUTF8);
-    if (p_key == null) return false;
-    defer CFRelease(p_key);
+    // FIFO-transport built-in keyboards don't expose VendorID/ProductID
+    // in IOKit. Including them with value 0 requires the property to
+    // *exist* on the device, so 0 devices match. Match by usage only
+    // and confirm a VID-less keyboard exists.
+    if (vendor != 0 or product != 0) {
+        const v_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDVendorIDKey, kCFStringEncodingUTF8);
+        if (v_key == null) return false;
+        defer CFRelease(v_key);
+        const p_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDProductIDKey, kCFStringEncodingUTF8);
+        if (p_key == null) return false;
+        defer CFRelease(p_key);
 
-    var v: i32 = @intCast(vendor);
-    var p: i32 = @intCast(product);
-    const v_num = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &v);
-    if (v_num == null) return false;
-    defer CFRelease(v_num);
-    const p_num = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &p);
-    if (p_num == null) return false;
-    defer CFRelease(p_num);
+        var v: i32 = @intCast(vendor);
+        var p: i32 = @intCast(product);
+        const v_num = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &v);
+        if (v_num == null) return false;
+        defer CFRelease(v_num);
+        const p_num = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &p);
+        if (p_num == null) return false;
+        defer CFRelease(p_num);
 
-    CFDictionarySetValue(dict, v_key, v_num);
-    CFDictionarySetValue(dict, p_key, p_num);
+        CFDictionarySetValue(dict, v_key, v_num);
+        CFDictionarySetValue(dict, p_key, p_num);
+    }
+
+    // Match Primary* (not Device*) for consistency with HidSeize.setMatches
+    // and Hidutil.buildMatching — composite devices can disagree on the
+    // two key families.
+    const up_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDPrimaryUsagePageKey, kCFStringEncodingUTF8);
+    if (up_key == null) return false;
+    defer CFRelease(up_key);
+    const u_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDPrimaryUsageKey, kCFStringEncodingUTF8);
+    if (u_key == null) return false;
+    defer CFRelease(u_key);
+
+    var page_val: i32 = usage_page_generic_desktop;
+    var usage_val: i32 = usage_keyboard;
+    const page_num = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &page_val);
+    if (page_num == null) return false;
+    defer CFRelease(page_num);
+    const usage_num = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &usage_val);
+    if (usage_num == null) return false;
+    defer CFRelease(usage_num);
+
+    CFDictionarySetValue(dict, up_key, page_num);
+    CFDictionarySetValue(dict, u_key, usage_num);
     CFArrayAppendValue(dicts, dict);
 
     IOHIDManagerSetDeviceMatchingMultiple(manager, dicts);
@@ -121,7 +151,26 @@ pub fn isPresent(vendor: u32, product: u32) bool {
     defer CFRelease(matched);
     const count = CFSetGetCount(matched);
     log.debug("vendor=0x{X:0>4} product=0x{X:0>4} → {d} match(es)", .{ vendor, product, count });
-    return count > 0;
+
+    if (vendor != 0 or product != 0) return count > 0;
+
+    // For 0/0: broad match includes the VHIDD. Confirm at least one
+    // matched device lacks a VendorID property (FIFO built-in keyboard).
+    if (count <= 0) return false;
+    const n: usize = @intCast(count);
+    const buf = std.heap.c_allocator.alloc(?*const anyopaque, n) catch return false;
+    defer std.heap.c_allocator.free(buf);
+    CFSetGetValues(matched, buf.ptr);
+
+    const vid_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDVendorIDKey, kCFStringEncodingUTF8);
+    if (vid_key == null) return false;
+    defer CFRelease(vid_key);
+
+    for (buf) |ref_const| {
+        const dev: IOHIDDeviceRef = @constCast(ref_const);
+        if (IOHIDDeviceGetProperty(dev, vid_key) == null) return true;
+    }
+    return false;
 }
 
 /// Print every connected HID keyboard as a paste-ready `.device`
@@ -139,9 +188,9 @@ pub fn printKeyboardList(allocator: std.mem.Allocator) !void {
     const match = CFDictionaryCreateMutable(kCFAllocatorDefault, 2, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks) orelse return error.OutOfMemory;
     defer CFRelease(match);
 
-    const up_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDDeviceUsagePageKey, kCFStringEncodingUTF8) orelse return error.OutOfMemory;
+    const up_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDPrimaryUsagePageKey, kCFStringEncodingUTF8) orelse return error.OutOfMemory;
     defer CFRelease(up_key);
-    const u_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDDeviceUsageKey, kCFStringEncodingUTF8) orelse return error.OutOfMemory;
+    const u_key = CFStringCreateWithCString(kCFAllocatorDefault, kIOHIDPrimaryUsageKey, kCFStringEncodingUTF8) orelse return error.OutOfMemory;
     defer CFRelease(u_key);
 
     var page_val: i32 = usage_page_generic_desktop;
@@ -202,8 +251,8 @@ pub fn printKeyboardList(allocator: std.mem.Allocator) !void {
     var printed: usize = 0;
     for (refs) |ref_const| {
         const dev: IOHIDDeviceRef = @constCast(ref_const);
-        const vendor = readU32Prop(dev, v_prop) orelse continue;
-        const product = readU32Prop(dev, p_prop) orelse continue;
+        const vendor = readU32Prop(dev, v_prop) orelse 0;
+        const product = readU32Prop(dev, p_prop) orelse 0;
 
         if (containsVendorProduct(seen.items, vendor, product)) continue;
         try seen.append(allocator, .{ .vendor = vendor, .product = product });

--- a/src/Hidutil.zig
+++ b/src/Hidutil.zig
@@ -201,15 +201,32 @@ fn applyForDevice(allocator: std.mem.Allocator, io: std.Io, vendor: u32, product
     try w.writeAll("]}");
 
     var matching_buf: [128]u8 = undefined;
-    const matching = try std.fmt.bufPrint(&matching_buf, "{{\"VendorID\":{d},\"ProductID\":{d}}}", .{ vendor, product });
+    const matching = try buildMatching(&matching_buf, vendor, product);
 
     try runHidutilSet(allocator, io, matching, json_buf.written());
 }
 
 fn clearForDevice(allocator: std.mem.Allocator, io: std.Io, vendor: u32, product: u32) !void {
     var matching_buf: [128]u8 = undefined;
-    const matching = try std.fmt.bufPrint(&matching_buf, "{{\"VendorID\":{d},\"ProductID\":{d}}}", .{ vendor, product });
+    const matching = try buildMatching(&matching_buf, vendor, product);
     try runHidutilSet(allocator, io, matching, "{\"UserKeyMapping\":[]}");
+}
+
+/// FIFO-transport built-in keyboards have no VendorID/ProductID in IOKit;
+/// hidutil treats `{"VendorID":0,"ProductID":0}` as a wildcard and applies
+/// the mapping to every connected keyboard. For the 0/0 case, match by
+/// `Built-In: 1` + keyboard usage so only the internal keyboard is touched.
+fn buildMatching(buf: []u8, vendor: u32, product: u32) ![]u8 {
+    if (vendor == 0 and product == 0) {
+        return std.fmt.bufPrint(buf, "{{\"Built-In\":1,\"PrimaryUsagePage\":1,\"PrimaryUsage\":6}}", .{});
+    }
+    // Partial-zero (one is 0, the other isn't) hits hidutil's wildcard
+    // semantics on the zero side — the mapping leaks to every keyboard
+    // that happens to match the non-zero side. Warn loudly.
+    if ((vendor == 0) != (product == 0)) {
+        log.warn("device alias with partial-zero VID/PID (vendor=0x{x}, product=0x{x}) will match unintended keyboards — use both zero for FIFO built-in, or both non-zero for an external device", .{ vendor, product });
+    }
+    return std.fmt.bufPrint(buf, "{{\"VendorID\":{d},\"ProductID\":{d}}}", .{ vendor, product });
 }
 
 fn runHidutilSet(allocator: std.mem.Allocator, io: std.Io, matching: []const u8, set_value: []const u8) !void {
@@ -230,6 +247,26 @@ fn runHidutilSet(allocator: std.mem.Allocator, io: std.Io, matching: []const u8,
         log.err("hidutil failed (term={any}): {s}", .{ result.term, std.mem.trim(u8, result.stderr, " \r\n\t") });
         return error.HidutilFailed;
     }
+}
+
+test "buildMatching: non-zero VID/PID uses VendorID/ProductID predicate" {
+    var buf: [128]u8 = undefined;
+    const out = try buildMatching(&buf, 0x05AC, 0x0342);
+    try std.testing.expectEqualStrings("{\"VendorID\":1452,\"ProductID\":834}", out);
+}
+
+test "buildMatching: zero VID/PID uses Built-In predicate" {
+    var buf: [128]u8 = undefined;
+    const out = try buildMatching(&buf, 0, 0);
+    try std.testing.expectEqualStrings("{\"Built-In\":1,\"PrimaryUsagePage\":1,\"PrimaryUsage\":6}", out);
+}
+
+test "buildMatching: partial-zero still emits literal 0 (warning logged elsewhere)" {
+    var buf: [128]u8 = undefined;
+    const out_v = try buildMatching(&buf, 0, 0x1234);
+    try std.testing.expectEqualStrings("{\"VendorID\":0,\"ProductID\":4660}", out_v);
+    const out_p = try buildMatching(&buf, 0x1234, 0);
+    try std.testing.expectEqualStrings("{\"VendorID\":4660,\"ProductID\":0}", out_p);
 }
 
 test "VendorProduct round-trip via state file" {

--- a/src/grabber/HidSeize.zig
+++ b/src/grabber/HidSeize.zig
@@ -113,6 +113,14 @@ pub fn setMatches(self: *Self, matches: []const Match) !void {
     defer c.CFRelease(dicts);
 
     for (matches) |m| {
+        // Partial-zero (one of vendor/product is 0, the other isn't) takes
+        // the non-broad branch with a literal VendorID=0 or ProductID=0 in
+        // the matching dict — which matches no real device. Warn loudly so
+        // misconfigured aliases don't fail silently.
+        if ((m.vendor == 0) != (m.product == 0)) {
+            log.warn("device alias with partial-zero VID/PID (vendor=0x{x}, product=0x{x}) will match nothing — use both zero for FIFO built-in keyboards, or both non-zero for an external device", .{ m.vendor, m.product });
+        }
+
         const dict = c.CFDictionaryCreateMutable(
             c.kCFAllocatorDefault,
             4,
@@ -122,31 +130,39 @@ pub fn setMatches(self: *Self, matches: []const Match) !void {
         if (dict == null) return error.CFDictionaryCreateFailed;
         defer c.CFRelease(dict);
 
-        const vendor_key = c.CFStringCreateWithCString(c.kCFAllocatorDefault, c.kIOHIDVendorIDKey, c.kCFStringEncodingUTF8);
-        defer c.CFRelease(vendor_key);
-        const product_key = c.CFStringCreateWithCString(c.kCFAllocatorDefault, c.kIOHIDProductIDKey, c.kCFStringEncodingUTF8);
-        defer c.CFRelease(product_key);
+        // FIFO-transport built-in keyboards don't expose VendorID/ProductID
+        // in IOKit — including them with value 0 requires the property to
+        // *exist*, so 0 devices match. Omit when both are zero; the
+        // usage filter keeps us to keyboards. Un-seize the VHIDD in start().
+        if (m.vendor != 0 or m.product != 0) {
+            const vendor_key = c.CFStringCreateWithCString(c.kCFAllocatorDefault, c.kIOHIDVendorIDKey, c.kCFStringEncodingUTF8);
+            defer c.CFRelease(vendor_key);
+            const product_key = c.CFStringCreateWithCString(c.kCFAllocatorDefault, c.kIOHIDProductIDKey, c.kCFStringEncodingUTF8);
+            defer c.CFRelease(product_key);
+
+            var vendor: i32 = @intCast(m.vendor);
+            var product: i32 = @intCast(m.product);
+            const vendor_num = c.CFNumberCreate(c.kCFAllocatorDefault, c.kCFNumberSInt32Type, &vendor);
+            defer c.CFRelease(vendor_num);
+            const product_num = c.CFNumberCreate(c.kCFAllocatorDefault, c.kCFNumberSInt32Type, &product);
+            defer c.CFRelease(product_num);
+
+            c.CFDictionarySetValue(dict, vendor_key, vendor_num);
+            c.CFDictionarySetValue(dict, product_key, product_num);
+        }
+
         const usage_page_key = c.CFStringCreateWithCString(c.kCFAllocatorDefault, c.kIOHIDPrimaryUsagePageKey, c.kCFStringEncodingUTF8);
         defer c.CFRelease(usage_page_key);
         const usage_key = c.CFStringCreateWithCString(c.kCFAllocatorDefault, c.kIOHIDPrimaryUsageKey, c.kCFStringEncodingUTF8);
         defer c.CFRelease(usage_key);
 
-        var vendor: i32 = @intCast(m.vendor);
-        var product: i32 = @intCast(m.product);
         var usage_page: i32 = c.kHIDPage_GenericDesktop;
         var usage: i32 = c.kHIDUsage_GD_Keyboard;
-
-        const vendor_num = c.CFNumberCreate(c.kCFAllocatorDefault, c.kCFNumberSInt32Type, &vendor);
-        defer c.CFRelease(vendor_num);
-        const product_num = c.CFNumberCreate(c.kCFAllocatorDefault, c.kCFNumberSInt32Type, &product);
-        defer c.CFRelease(product_num);
         const usage_page_num = c.CFNumberCreate(c.kCFAllocatorDefault, c.kCFNumberSInt32Type, &usage_page);
         defer c.CFRelease(usage_page_num);
         const usage_num = c.CFNumberCreate(c.kCFAllocatorDefault, c.kCFNumberSInt32Type, &usage);
         defer c.CFRelease(usage_num);
 
-        c.CFDictionarySetValue(dict, vendor_key, vendor_num);
-        c.CFDictionarySetValue(dict, product_key, product_num);
         c.CFDictionarySetValue(dict, usage_page_key, usage_page_num);
         c.CFDictionarySetValue(dict, usage_key, usage_num);
 
@@ -203,7 +219,44 @@ pub fn start(self: *Self, mode: Mode) !void {
     if (count == 0) {
         log.warn("matching dictionary captured 0 devices — vendor/product mismatch?", .{});
     }
-    if (matched) |s| c.CFRelease(s);
+
+    // Broad usage-only match (vendor/product both zero) also captures
+    // the Karabiner VHIDD. Un-seize any device with a non-zero VendorID
+    // to avoid a feedback loop — we inject *through* the VHIDD.
+    const has_broad_match = for (self.owned_matches) |m| {
+        if (m.vendor == 0 and m.product == 0) break true;
+    } else false;
+
+    if (matched) |s| {
+        if (has_broad_match) un_seize: {
+            const n: usize = @intCast(c.CFSetGetCount(s));
+            if (n == 0) break :un_seize;
+            const buf = self.allocator.alloc(?*const anyopaque, n) catch {
+                log.warn("un-seize buffer alloc failed; VHIDD may stay seized", .{});
+                break :un_seize;
+            };
+            defer self.allocator.free(buf);
+            c.CFSetGetValues(s, buf.ptr);
+
+            const vid_key = c.CFStringCreateWithCString(c.kCFAllocatorDefault, c.kIOHIDVendorIDKey, c.kCFStringEncodingUTF8);
+            defer if (vid_key) |k| c.CFRelease(k);
+
+            for (buf) |raw| {
+                const dev: c.IOHIDDeviceRef = @constCast(raw);
+                if (vid_key) |k| {
+                    const prop = c.IOHIDDeviceGetProperty(dev, k);
+                    if (prop != null) {
+                        var vid: i32 = 0;
+                        if (c.CFNumberGetValue(@ptrCast(prop), c.kCFNumberSInt32Type, @ptrCast(&vid)) != 0 and vid != 0) {
+                            log.debug("un-seizing device with VendorID=0x{x} (not the target)", .{@as(u32, @bitCast(vid))});
+                            _ = c.IOHIDDeviceClose(dev, self.open_options);
+                        }
+                    }
+                }
+            }
+        }
+        c.CFRelease(s);
+    }
 
     if (mode == .seize) {
         self.disableCapsLockDelayOnMatches(self.owned_matches);

--- a/src/grabber/c.zig
+++ b/src/grabber/c.zig
@@ -175,6 +175,8 @@ pub extern fn IOHIDManagerCopyDevices(manager: IOHIDManagerRef) ?*anyopaque; // 
 pub extern fn CFSetGetCount(theSet: ?*anyopaque) CFIndex;
 pub extern fn CFSetGetValues(theSet: ?*anyopaque, values: [*]?*const anyopaque) void;
 pub extern fn IOHIDDeviceSetProperty(device: IOHIDDeviceRef, key: CFStringRef, property: CFTypeRef) Boolean;
+pub extern fn IOHIDDeviceGetProperty(device: IOHIDDeviceRef, key: CFStringRef) CFTypeRef;
+pub extern fn IOHIDDeviceClose(device: IOHIDDeviceRef, options: u32) IOReturn;
 
 // Private IOHIDEventSystemClient API. These symbols are in
 // IOKit.framework but live in the private header


### PR DESCRIPTION
On my M3 Max MacBook Pro (Mac15,10), the built-in keyboard uses Apple's FIFO transport and doesn't expose `VendorID` or `ProductID` in IOKit at all — `hidutil list` reports `0x0/0x0` as a fallback, but the registry properties are genuinely absent. So `.device builtin { vendor: 0x0, product: 0x0 }` falls into three different traps:

- The grabber's IOHIDManager match includes `VendorID:0, ProductID:0` in the matching dict, which requires the property to exist on the device — matches zero devices, `applyLatestRules failed: NotPermitted` after a retry storm.
- `DeviceCheck.isPresent` has the same problem and returns false, so the agent never even dials the grabber for `[device builtin]` rules.
- `hidutil property --matching '{"VendorID":0,"ProductID":0}'` is treated as a wildcard instead, applying the `UserKeyMapping` to every connected keyboard. Plugging in an external keyboard reveals it: backslash/backspace get swapped on the external too.

So block-form rules silently no-op on the built-in, and colon-form rules leak onto external keyboards. Three different matching APIs, three different wrong behaviors for the same input.

`HidSeize.setMatches` (grabber): when both vendor and product are zero, drop them from the matching dict so the usage-page filter does the work. After `IOHIDManagerOpen`, walk the matched set and call `IOHIDDeviceClose` on anything that does have a non-zero `VendorID` — that's the Karabiner VHIDD, and seizing it would feed back through the inject path.

`DeviceCheck.isPresent` (agent): same conditional VID/PID skip. Post-match, confirm at least one matched device lacks a `VendorID` property — otherwise on a Mac with no built-in keyboard, the VHIDD alone would make `isPresent(0, 0)` return true.

`Hidutil.buildMatching` (colon form): for `0/0`, switch to `{"Built-In":1,"PrimaryUsagePage":1,"PrimaryUsage":6}` so `hidutil property --set` scopes to the internal keyboard only. Other `(vendor, product)` pairs use the existing predicate.

`DeviceCheck.printKeyboardList` (`--list-devices`): previously `readU32Prop(...) orelse continue` silently dropped VID-less keyboards, hiding the built-in. They show as `vendor: 0x0, product: 0x0` now so users can target them.

Also aligned `DeviceCheck` to use `PrimaryUsagePage`/`PrimaryUsage` (matching `HidSeize` and `Hidutil`) so all three paths see the same set of devices, and added a `log.warn` in `setMatches` and `buildMatching` for partial-zero IDs — that combination matches nothing in HidSeize and triggers the wildcard leak in Hidutil, which is otherwise hard to debug. Three tests cover the `buildMatching` branches.

Tested on the M3 Max with an external USB keyboard connected: caps_lock tap/hold fires on the built-in only, backslash/backspace swap is built-in only, tab layer hold works on the built-in, `zig build test` is green (20/20 + 7/7).

A few things I left alone: pre-patch crash state with a `(0, 0)` entry was applied as a hidutil wildcard, so after this change `clearForDevice(0, 0)` only cleans up the built-in and any external keyboards previously affected stay remapped until cleared manually. `u32 → i32 @intCast` will panic if a config specifies vendor or product above `0x7FFFFFFF`; real IDs are u16, so this is config-input fragility rather than a device-driven crash. And `--list-devices` dedups by `(vendor, product)`, so multiple VID-less keyboard-class services on the same Mac collapse to one line — cosmetic, doesn't affect matching. All three are worth fixing but feel scope-creepy for this PR.
